### PR TITLE
Allow people to use parameters with certain wands, allow people to use w:current to use the current world. bug 327:resolved [the other half of the issue was already done by @botskonet] and bug 528:resolved . Re-worked the Flags Enum so that ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,13 @@
 		   <scope>system</scope>
 		   <systemPath>${project.basedir}/../LIBS/Herochat.jar</systemPath>
 	   </dependency>
-	</dependencies>
+  	   <dependency>
+  	      <groupId>org.bukkit</groupId>
+  	      <artifactId>craftbukkit</artifactId>
+  	      <version>1.5-R0.1-SNAPSHOT</version>
+  	      <type>jar</type>
+  	   </dependency>
+  	</dependencies>
 	<repositories>
 		<repository>
 			<id>dhmc-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   		<dependency>
 			<groupId>me.botsko</groupId>
 			<artifactId>elixr</artifactId>
-			<version>1.0-dev-17-g62eb894-SNAPSHOT</version>
+			<version>1.0-dev-21-g9892ef2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bukkit</groupId>
@@ -37,17 +37,11 @@
 		   <scope>system</scope>
 		   <systemPath>${project.basedir}/../LIBS/Herochat.jar</systemPath>
 	   </dependency>
-  	   <dependency>
-  	      <groupId>org.bukkit</groupId>
-  	      <artifactId>craftbukkit</artifactId>
-  	      <version>1.5-R0.1-SNAPSHOT</version>
-  	      <type>jar</type>
-  	   </dependency>
   	</dependencies>
 	<repositories>
 		<repository>
 			<id>dhmc-repo</id>
-			<url>http://dhmc.us:8081/nexus/content/repositories</url>
+			<url>http://dhmc.us:8081/nexus/content/repositories/snapshots</url>
 		</repository>
 		<repository>
 			<id>repobo-snap</id>

--- a/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
@@ -166,6 +166,10 @@ public class ActionsQuery {
 				plugin.cachedQueries.remove(keyName);
 			}
 			plugin.cachedQueries.put(keyName, res);
+			// We also need to share these results with the -share-with players.
+			for(String sharedPlayer : parameters.getShared_players()){
+				plugin.cachedQueries.put(sharedPlayer, res);
+			}
 		}
 		
 		plugin.eventTimer.recordTimedEvent("results object completed");

--- a/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
@@ -51,6 +51,7 @@ public class QueryParameters implements Cloneable {
 	protected HashMap<String,MatchRule> entity_filters = new HashMap<String,MatchRule>();
 	protected HashMap<String,MatchRule> player_names = new HashMap<String,MatchRule>();
 	protected ArrayList<Flag> flags = new ArrayList<Flag>();
+	protected ArrayList<String> shared_players = new ArrayList<String>();
 	
 	/**
 	 * Pagination
@@ -561,6 +562,21 @@ public class QueryParameters implements Cloneable {
 		return original_command;
 	}
 	
+	/**
+	 * Get the players that you're sharing your lookup with.
+	 * @return
+	 */
+	public ArrayList<String> getShared_players(){
+		return shared_players;
+	}
+	
+	/**
+	 * Set the players you're sharing the lookup with.
+	 * @param players 
+	 */
+	public void addShared_player(String player){
+		this.shared_players.add(player);
+	}
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/commandlibs/Flag.java
+++ b/src/main/java/me/botsko/prism/commandlibs/Flag.java
@@ -1,13 +1,42 @@
 package me.botsko.prism.commandlibs;
 
 public enum Flag {
-	DRAIN,
-	DRAIN_LAVA,
-	DRAIN_WATER,
-	EXTENDED,
-	NO_EXT,
-	NO_ITEMCLEAR,
-	PER_PAGE,
-	NO_GROUP,
-	OVERWRITE
+	DRAIN("Drain liquid along with a rollback."),
+	DRAIN_LAVA("Drain only lava along with a rollback."),
+	DRAIN_WATER("Drain only water along with a rollback."),
+	EXTENDED("Shows the extended lookup results (timestamp, coords, id, etc)."),
+	NO_EXT("Do not extinguish fires on burn rollbacks."),
+	NO_ITEMCLEAR("Do not clear drops on explosion rollback."),
+	PER_PAGE("-per-page=#", "Set results per-page for current lookup."),
+	NO_GROUP("Disables grouping of related actions."),
+	OVERWRITE("Forces rb/rs to not skip blocks if something unexpected is at location."),
+	SHARE("-share=player1[,player2...]", "Share a lookup result with another player.");
+	
+	private String description;
+	private String usage;
+	
+	
+	public String getDescription(){
+		return description;
+	}
+	
+	public String getUsage(){
+		if(usage.isEmpty()){
+			usage = "-" + this.name().toLowerCase();
+		}
+		return usage;
+	}
+	
+	/**
+	 * Defaults {@link #usage} to -(flagname) 
+	 * @param description 
+	 */
+	private Flag(String description){
+		this("", description); // We can't use this.name() in a constructor so we defer it to the getUsage.
+	} 
+	
+	private Flag(String usage, String description){
+		this.usage = usage;
+		this.description = description;
+	}
 }

--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -18,6 +18,7 @@ import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
 import me.botsko.prism.bridge.WorldEditBridge;
 import me.botsko.prism.utils.LevenshteinDistance;
+import org.bukkit.Bukkit;
 
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -348,6 +349,17 @@ public class PreprocessArgs {
 									} else {
 										respond( sender, Prism.messenger.playerError("Per-page flag value must be a number. Use /prism ? for help.") );
 										return null;
+									}
+								} else if (flag.equals(Flag.SHARE)){
+									for(String sharePlayer : flagComponents[1].split(",")){
+										if(sharePlayer.equals(sender.getName())){
+											sender.sendMessage(Prism.messenger.playerError( "You can't share lookup results with yourself, silly!" ));
+										}
+										if(plugin.getServer().getPlayer(sharePlayer) != null || sharePlayer.equalsIgnoreCase("CONSOLE")){
+											parameters.addShared_player(sharePlayer);
+										} else {
+											sender.sendMessage(Prism.messenger.playerError( "I can't share the results with '" + sharePlayer + "' because I can't find them. Are they not online? Check your spelling." ));
+										}
 									}
 								}
 							}

--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -167,6 +167,9 @@ public class PreprocessArgs {
 				
 				// World
 				if(arg_type.equals("w")){
+					if(val.equalsIgnoreCase("current")){
+						val = player.getWorld().getName();
+					}
 					parameters.setWorld( val );
 				}
 				

--- a/src/main/java/me/botsko/prism/commands/FlagsCommand.java
+++ b/src/main/java/me/botsko/prism/commands/FlagsCommand.java
@@ -5,6 +5,7 @@ import org.bukkit.command.CommandSender;
 
 import me.botsko.prism.Prism;
 import me.botsko.prism.commandlibs.CallInfo;
+import me.botsko.prism.commandlibs.Flag;
 import me.botsko.prism.commandlibs.SubHandler;
 
 public class FlagsCommand implements SubHandler {
@@ -28,16 +29,8 @@ public class FlagsCommand implements SubHandler {
 
 		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.GRAY + "Flags control how Prism applies a rollback/restore, or formats lookup results." ) );
 		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.GRAY + "Use them after parameters, like /pr l p:viveleroi -extended" ) );
-		
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-drain" + ChatColor.WHITE + " Drain liquid along with a rollback.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-drain-lava" + ChatColor.WHITE + " Drain only lava along with a rollback.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-drain-water" + ChatColor.WHITE + " Drain only water along with a rollback.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-extended" + ChatColor.WHITE + " Shows the extended lookup results (timestamp, coords, id, etc).") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-no-ext" + ChatColor.WHITE + " Do not extinguish fires on burn rollbacks.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-no-group" + ChatColor.WHITE + " Disables grouping of related actions.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-no-item-clear" + ChatColor.WHITE + " Do not clear drops on explosion rollback.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-overwrite" + ChatColor.WHITE + " Forces rb/rs to not skip blocks if something unexpected is at location.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "-per-page=#" + ChatColor.WHITE + " Set results per-page for current lookup.") );
-		
+		for(Flag flag : Flag.values()){
+			sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + flag.getUsage().replace("_", "-") + ChatColor.WHITE + " " + flag.getDescription() ) );
+		}
 	}
 }

--- a/src/main/java/me/botsko/prism/commands/WandCommand.java
+++ b/src/main/java/me/botsko/prism/commands/WandCommand.java
@@ -226,7 +226,9 @@ public class WandCommand implements SubHandler {
 			
 			// Let's build the QueryParameters for it if it's a Query wand.
 			if(wand instanceof QueryWandBase){
-				((QueryWandBase) wand).setParameters(call.getPlayer(), call.getArgs(), (isInspect ? 1 : 2));
+				if(!((QueryWandBase) wand).setParameters(call.getPlayer(), call.getArgs(), (isInspect ? 1 : 2))){ // This returns if it was successful
+					call.getPlayer().sendMessage( Prism.messenger.playerError("Warning: Only some parameters may be in effect. Re-enter your command, fixing any issues in it, to make sure all parameters work.") );
+				}
 			}
 			
 			// Store

--- a/src/main/java/me/botsko/prism/commands/WandCommand.java
+++ b/src/main/java/me/botsko/prism/commands/WandCommand.java
@@ -12,6 +12,7 @@ import me.botsko.prism.settings.Settings;
 import me.botsko.prism.utils.ItemUtils;
 import me.botsko.prism.wands.InspectorWand;
 import me.botsko.prism.wands.ProfileWand;
+import me.botsko.prism.wands.QueryWandBase;
 import me.botsko.prism.wands.RestoreWand;
 import me.botsko.prism.wands.RollbackWand;
 import me.botsko.prism.wands.Wand;
@@ -38,9 +39,9 @@ public class WandCommand implements SubHandler {
 	 * Handle the command
 	 */
 	public void handle(CallInfo call) {
-		
 		String type = "i";
-		if(call.getArgs().length == 2){
+		boolean isInspect = call.getArg(0).equalsIgnoreCase("inspect") || call.getArg(0).equalsIgnoreCase("i");
+		if(!isInspect){
 			type = call.getArg(1);
 		}
 		
@@ -95,13 +96,21 @@ public class WandCommand implements SubHandler {
 		
 		String wandOn = "";
 		String item_name = "";
+		String parameters = "";
 		if( item_id != 0 ){
 			item_name = plugin.getItems().getAlias(item_id, item_subid);
 			wandOn += " on a " + item_name;
 		}
 		
+		for(int i = (isInspect ? 1 : 2); i < call.getArgs().length; i++){
+			if(parameters.isEmpty()){
+				parameters += " with parameters:";
+			}
+			parameters += " " + call.getArg(i);
+		}
+		
 		if( !ItemUtils.isAcceptableWand( item_id, item_subid ) ){
-			call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry but you may not use " + item_name + " for a wand.") );
+			call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but you may not use " + item_name + " for a wand.") );
 			return;
 		}
 		
@@ -120,7 +129,7 @@ public class WandCommand implements SubHandler {
 				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Inspection wand " + ChatColor.RED + "disabled"+ChatColor.WHITE+".") );
 			} else {
 				wand = new InspectorWand( plugin );
-				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Inspection wand " + ChatColor.GREEN + "enabled"+ChatColor.WHITE+wandOn+".") );
+				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Inspection wand " + ChatColor.GREEN + "enabled"+ChatColor.WHITE+wandOn+parameters+".") );
 				enabled = true;
 			}
 		}
@@ -155,7 +164,7 @@ public class WandCommand implements SubHandler {
 				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Rollback wand " + ChatColor.RED + "disabled"+ChatColor.WHITE+".") );
 			} else {
 				wand = new RollbackWand( plugin );
-				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Rollback wand " + ChatColor.GREEN + "enabled"+ChatColor.WHITE+wandOn+".") );
+				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Rollback wand " + ChatColor.GREEN + "enabled"+ChatColor.WHITE+wandOn+parameters+".") );
 				enabled = true;
 			}
 		}
@@ -173,7 +182,7 @@ public class WandCommand implements SubHandler {
 				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Restore wand " + ChatColor.RED + "disabled"+ChatColor.WHITE+".") );
 			} else {
 				wand = new RestoreWand( plugin );
-				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Restore wand " + ChatColor.GREEN + "enabled"+ChatColor.WHITE+wandOn+".") );
+				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Restore wand " + ChatColor.GREEN + "enabled"+ChatColor.WHITE+wandOn+parameters+".") );
 				enabled = true;
 			}
 		}
@@ -214,6 +223,12 @@ public class WandCommand implements SubHandler {
 				}
 				call.getPlayer().updateInventory();
 			}
+			
+			// Let's build the QueryParameters for it if it's a Query wand.
+			if(wand instanceof QueryWandBase){
+				((QueryWandBase) wand).setParameters(call.getPlayer(), call.getArgs(), (isInspect ? 1 : 2));
+			}
+			
 			// Store
 			plugin.playersWithActiveTools.put(call.getPlayer().getName(), wand);
 		} else {

--- a/src/main/java/me/botsko/prism/wands/InspectorWand.java
+++ b/src/main/java/me/botsko/prism/wands/InspectorWand.java
@@ -16,13 +16,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
-public class InspectorWand extends WandBase implements Wand {
-	
-	
-	/**
-	 * 
-	 */
-	private Prism plugin;
+public class InspectorWand extends QueryWandBase implements Wand {
 
 	
 	
@@ -31,7 +25,7 @@ public class InspectorWand extends WandBase implements Wand {
 	 * @param plugin
 	 */
 	public InspectorWand( Prism plugin ){
-		this.plugin = plugin;
+		super(plugin);
 	}
 	
 	
@@ -60,7 +54,14 @@ public class InspectorWand extends WandBase implements Wand {
 	protected void showBlockHistory( Player player, Block block, Location loc ){
 
 		// Build params
-		QueryParameters params = new QueryParameters();
+		QueryParameters params;
+		
+		try {
+			params = parameters.clone();
+		} catch (CloneNotSupportedException ex) {
+			params = new QueryParameters();
+			player.sendMessage(Prism.messenger.playerError(ChatColor.YELLOW + "Warning: An error occurred while trying to retrieve the params from this wand. Checking with default parameters."));
+		}
 		params.setWorld( player.getWorld().getName() );
 		params.setSpecificBlockLocation(loc);
 		

--- a/src/main/java/me/botsko/prism/wands/InspectorWand.java
+++ b/src/main/java/me/botsko/prism/wands/InspectorWand.java
@@ -8,6 +8,7 @@ import me.botsko.prism.actionlibs.ActionsQuery;
 import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.actionlibs.QueryResult;
+import me.botsko.prism.commandlibs.Flag;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -85,6 +86,9 @@ public class InspectorWand extends QueryWandBase implements Wand {
 			}
 			for(me.botsko.prism.actions.Handler a : results.getPaginatedActionResults()){
 				ActionMessage am = new ActionMessage(a);
+				if( parameters.hasFlag(Flag.EXTENDED) || plugin.getConfig().getBoolean("prism.messenger.always-show-extended") ){
+					am.showExtended();
+				}
 				player.sendMessage( Prism.messenger.playerMsg( am.getMessage() ) );
 			}
 		} else {

--- a/src/main/java/me/botsko/prism/wands/QueryWandBase.java
+++ b/src/main/java/me/botsko/prism/wands/QueryWandBase.java
@@ -1,20 +1,10 @@
 package me.botsko.prism.wands;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.concurrent.ConcurrentHashMap;
-import me.botsko.prism.MaterialAliases;
 import me.botsko.prism.Prism;
-import me.botsko.prism.actionlibs.ActionType;
-import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
-import me.botsko.prism.commandlibs.Flag;
 import me.botsko.prism.commandlibs.PreprocessArgs;
-import me.botsko.prism.utils.BlockUtils;
-import me.botsko.prism.utils.LevenshteinDistance;
-import me.botsko.prism.utils.TypeUtils;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -49,262 +39,26 @@ public abstract class QueryWandBase extends WandBase {
 	
 	/**
 	 * Set the field {@link #parameters} with the parameters here.
-	 * This will be using the stuff in <code>/prism params</code>, except we will
-	 * ignore the radius and world because we're only checking a single block.
-	 * <b>This is only a slightly modified version of
-	 * {@link 
-	 * me.botsko.prism.commandlibs.PreprocessArgs#process(me.botsko.prism.Prism,
-	 * org.bukkit.command.CommandSender, 
-	 * java.lang.String[], 
-	 * me.botsko.prism.appliers.PrismProcessType, 
-	 * int) 
-	 * PreprcessArgs's process(...)}.</b> method. At some point we should try to
-	 * combine the two methods, and maybe split up process(...) to make it more
-	 * usable in other ways.
+	 * This will be using the stuff in <code>/prism params</code>
 	 * @param sender The sender of the command.
 	 * @param args The arguments from <code>/prism params</code>.
 	 * @param argStart What argument to start on.
 	 */
 	public boolean setParameters(Player sender, String[] args, int argStart){
+		PrismProcessType processType = this instanceof RollbackWand ? PrismProcessType.ROLLBACK 
+				: this instanceof RestoreWand ? PrismProcessType.RESTORE 
+				: this instanceof InspectorWand ? PrismProcessType.LOOKUP 
+				: PrismProcessType.LOOKUP;
 		
-		ConcurrentHashMap<String,String> foundArgs = new ConcurrentHashMap<String,String>();
+		String[] newArgs = Arrays.copyOf(args, args.length + 1);
 		
-		if(args != null){
-
-			// Iterate over arguments
-			for (int i = argStart; i < args.length; i++){
-
-				String arg = args[i];
-				if (arg.isEmpty()) continue;
-				
-				// Split parameter and values
-				String[] argEntry = arg.toLowerCase().split(":");
-				String arg_type = argEntry[0];
-				String val = arg.contains(":") ? arg.replace(argEntry[0] + ":", "") : argEntry[0];
-				
-				// Verify we have an arg we can match
-				String[] possibleArgs = {"a","t","p","b","e","k","before","since","id","-"}; // Removed "w", "r".
-				if(!Arrays.asList(possibleArgs).contains(arg_type) && !arg_type.startsWith("-")){
-					
-					// We support an alternate player syntax so that people can use the tab-complete
-					// feature of minecraft. Using p: prevents it.
-					Player autoFillPlayer = plugin.getServer().getPlayer(arg_type);
-					if( autoFillPlayer != null ){
-						MatchRule match = MatchRule.INCLUDE;
-						if(arg_type.startsWith("!")){
-							match = MatchRule.EXCLUDE;
-						}
-						parameters.addPlayerName( arg_type.replace("!", ""), match );
-					} else {
-						respond( sender, Prism.messenger.playerError( "Unrecognized parameter '"+arg+"' - Using only previous parameters. "+ChatColor.ITALIC+"Keep in mind that using parameter wands ignore radius and world parameters."+ChatColor.RED+" Use /prism ? for help.") );
-						parameters = new QueryParameters();
-						return false;
-					}
-				}
-				
-				// Verify no empty val
-				if(val.isEmpty()){
-					respond( sender, Prism.messenger.playerError("Can't use empty values for '"+arg+"' - Using only previous parameters. Use /prism ? for help.") );
-					return false;
-				}
-				
-				// Officially certify we found a valid argument and value!
-				if(Arrays.asList(possibleArgs).contains(arg_type)){
-					foundArgs.put(arg_type, val);
-					parameters.setFoundArgs(foundArgs);
-				}
-				
-				// Action
-				if(arg_type.equals("a")){
-					String[] actions = val.split(",");
-					if(actions.length > 0){
-						for(String action : actions){
-							// Find all actions that match the action provided - whether the full name or
-							// short name.
-							ArrayList<ActionType> actionTypes = Prism.getActionRegistry().getActionsByShortname( action.replace("!", "") );
-							if(!actionTypes.isEmpty()){
-								for(ActionType actionType : actionTypes){
-									
-									// Ensure the action allows this process type
-//									if( (processType.equals(PrismProcessType.ROLLBACK) && !actionType.canRollback()) || (processType.equals(PrismProcessType.RESTORE) && !actionType.canRestore()) ){
-										// @todo this is important information but is too spammy with a:place, because vehicle-place doesn't support a rollback etc
-//										respond( sender, Prism.messenger.playerError("Ingoring action '"+actionType.getName()+"' because it doesn't support rollbacks.") );
-//										continue;
-//									}
-									// Commented because we check for this later.
-									
-									// Check match type
-									MatchRule match = MatchRule.INCLUDE;
-									if(action.startsWith("!")){
-										match = MatchRule.EXCLUDE;
-									}
-									parameters.addActionType( actionType.getName(), match );
-								}
-							} else {
-								respond( sender, Prism.messenger.playerError("Ignoring action '"+action.replace("!", "")+"' because it's unrecognized. Did you mean '" + LevenshteinDistance.getClosestAction(action) +"'? Type '/prism params' for help.") );
-							}
-						}
-						// If none were valid, we end here.
-						if(parameters.getActionTypes().isEmpty()){
-							return false;
-						}
-					}
-				}
-				
-				// Player
-				if(arg_type.equals("p")){
-					String[] playerNames = val.split(",");
-					if(playerNames.length > 0){
-						for(String playerName : playerNames){
-							MatchRule match = MatchRule.INCLUDE;
-							if(playerName.startsWith("!")){
-								match = MatchRule.EXCLUDE;
-								playerName = playerName.replace("!", "");
-							}
-							else if(playerName.startsWith("~")){
-								match = MatchRule.PARTIAL;
-								playerName = playerName.replace("~", "");
-							}
-							parameters.addPlayerName( playerName, match );
-						}
-					}
-				}
-				
-				// Entity
-				if(arg_type.equals("e")){
-					String[] entityNames = val.split(",");
-					if(entityNames.length > 0){
-						for(String entityName : entityNames){
-							MatchRule match = MatchRule.INCLUDE;
-							if(entityName.startsWith("!")){
-								match = MatchRule.EXCLUDE;
-							}
-							parameters.addEntity( entityName.replace("!", ""), match );
-						}
-					}
-				}
-				
-				// Block
-				if(arg_type.equals("b")){
-					
-					String[] blocks = val.split(",");
-					
-					if(blocks.length > 0){
-						for(String b : blocks){
-					
-							// if user provided id:subid
-							if(b.contains(":") && b.length() >= 3){
-								String[] ids = b.split(":");
-								if(ids.length == 2 && TypeUtils.isNumeric(ids[0]) && TypeUtils.isNumeric(ids[1])){
-									parameters.addBlockFilter( Integer.parseInt( ids[0] ), Byte.parseByte( ids[1] ) );
-								} else {
-									respond( sender, Prism.messenger.playerError("Invalid block filter '"+val+"' - Using only previous parameters. Use /prism ? [command] for help.") );
-									return false;
-								}
-							} else {
-								
-								// It's id without a subid
-								if(TypeUtils.isNumeric(b)){
-									parameters.addBlockFilter( Integer.parseInt(b), (byte)0 );
-								} else {
-									
-									// Lookup the item name, get the ids
-									MaterialAliases items = plugin.getItems();
-									ArrayList<int[]> itemIds = items.getItemIdsByAlias( b );
-									if(itemIds.size() > 0){
-										for(int[] ids : itemIds){
-											if(ids.length == 2){
-												// If we really care about the sub id because it's a whole different item
-												if(BlockUtils.hasSubitems(ids[0])){
-													parameters.addBlockFilter( ids[0], (byte) ids[1] );
-												} else {
-													parameters.addBlockFilter( ids[0], (byte)0 );
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-				
-				// Time
-				if(arg_type.equals("before")){
-					String date = PreprocessArgs.translateTimeStringToDate(plugin,sender,val);
-					if(date != null){
-						parameters.setBeforeTime( date );
-					} else {
-						return false;
-					}
-				}
-				if( arg_type.equals("since") || arg_type.equals("t") ){
-					String date = PreprocessArgs.translateTimeStringToDate(plugin,sender,val);
-					if(date != null){
-						parameters.setSinceTime( date );
-					} else {
-						return false;
-					}
-				}
-				
-				// Keyword
-				if(arg_type.equals("k")){
-					parameters.setKeyword( val );
-				}
-				
-				// ID
-				if(arg_type.equals("id")){
-					
-					if(TypeUtils.isNumeric( val )){
-						
-					} else {
-						respond( sender, Prism.messenger.playerError("ID must be a number - Using only previous parameters. Use /prism ? for help.") );
-						return false;
-					}
-					parameters.setId( Integer.parseInt(val) );
-				}
-				
-				// Special Flags
-				if(arg_type.startsWith("-")){
-					try {
-						String[] flagComponents = val.substring(1).split("=");
-						Flag flag = Flag.valueOf( flagComponents[0].replace("-", "_").toUpperCase() );
-						if(!(parameters.hasFlag(flag))){
-								
-							parameters.addFlag(flag);
-							
-							// Flag has a value
-							if( flagComponents.length > 1 ){
-								if(flag.equals(Flag.PER_PAGE)){
-									if(TypeUtils.isNumeric(flagComponents[1])){
-										parameters.setPerPage( Integer.parseInt(flagComponents[1]) );
-									} else {
-										respond( sender, Prism.messenger.playerError("Per-page flag value must be a number - Using only previous parameters. Use /prism ? for help.") );
-										return false;
-									}
-								}
-							}
-						}
-					} catch(IllegalArgumentException ex){
-						respond( sender, Prism.messenger.playerError("Unrecognized flag '"+val+"' - Using only previous parameters. Use /prism ? [command] for help.") );
-						return false;
-					}
-				}
-			}	
-		}
-		return true;
-	}
-	
-	/**
-	 * For use in {@link #setParameters(org.bukkit.entity.Player, java.lang.String[]) setParameters(...)}
-	 * @param sender
-	 * @param msg
-	 */
-	private static void respond( CommandSender sender, String msg ){
-		if(sender != null){
-			sender.sendMessage(msg);
+		newArgs[args.length] = "w:current"; // The thing needs at least one argument, and it's going to be the current world anyway.
+		QueryParameters params = PreprocessArgs.process(plugin, sender, newArgs, processType, argStart);
+		if(params == null){
+			return false;
 		} else {
-//			System.out.print(msg); // @todo let this output to console, is useful for db purge debugging
+			this.parameters = params;
+			return true;
 		}
 	}
 	

--- a/src/main/java/me/botsko/prism/wands/QueryWandBase.java
+++ b/src/main/java/me/botsko/prism/wands/QueryWandBase.java
@@ -1,0 +1,319 @@
+package me.botsko.prism.wands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import me.botsko.prism.MaterialAliases;
+import me.botsko.prism.Prism;
+import me.botsko.prism.actionlibs.ActionType;
+import me.botsko.prism.actionlibs.MatchRule;
+import me.botsko.prism.actionlibs.QueryParameters;
+import me.botsko.prism.appliers.PrismProcessType;
+import me.botsko.prism.bridge.WorldEditBridge;
+import me.botsko.prism.commandlibs.Flag;
+import me.botsko.prism.commandlibs.PreprocessArgs;
+import me.botsko.prism.utils.BlockUtils;
+import me.botsko.prism.utils.LevenshteinDistance;
+import me.botsko.prism.utils.TypeUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * A base class for Wands that use 
+ * {@link me.botsko.prism.actionlibs.QueryParameters} and show results.
+ * This will allow users to specify parameters when creating the wand
+ * and have them saved in the Wand for every time they use it until
+ * it is disabled.
+ */
+public abstract class QueryWandBase extends WandBase {
+	
+	/**
+	 * The parameters that are specified. Whenever we do a search
+	 * we can clone this and then add the extra stuff. (Location, etc)
+	 */
+	protected QueryParameters parameters;
+	
+	/**
+	 * Keep an instance of {@link me.botsko.prism.Prism Prism} to use.
+	 */
+	protected Prism plugin;
+	
+	/**
+	 * When we initialize the class, make the {@link #parameters}
+	 * equal to a fresh QueryParameters.
+	 */
+	public QueryWandBase(Prism plugin){
+		parameters = new QueryParameters();
+		this.plugin = plugin;
+	}
+	
+	/**
+	 * Set the field {@link #parameters} with the parameters here.
+	 * This will be using the stuff in <code>/prism params</code>, except we will
+	 * ignore the radius and world because we're only checking a single block.
+	 * <b>This is only a slightly modified version of
+	 * {@link 
+	 * me.botsko.prism.commandlibs.PreprocessArgs#process(me.botsko.prism.Prism,
+	 * org.bukkit.command.CommandSender, 
+	 * java.lang.String[], 
+	 * me.botsko.prism.appliers.PrismProcessType, 
+	 * int) 
+	 * PreprcessArgs's process(...)}.</b> method. At some point we should try to
+	 * combine the two methods, and maybe split up process(...) to make it more
+	 * usable in other ways.
+	 * @param sender The sender of the command.
+	 * @param args The arguments from <code>/prism params</code>.
+	 * @param argStart What argument to start on.
+	 */
+	public boolean setParameters(Player sender, String[] args, int argStart){
+		
+		ConcurrentHashMap<String,String> foundArgs = new ConcurrentHashMap<String,String>();
+		
+		if(args != null){
+
+			// Iterate over arguments
+			for (int i = argStart; i < args.length; i++){
+
+				String arg = args[i];
+				if (arg.isEmpty()) continue;
+				
+				// Split parameter and values
+				String[] argEntry = arg.toLowerCase().split(":");
+				String arg_type = argEntry[0];
+				String val = arg.contains(":") ? arg.replace(argEntry[0] + ":", "") : argEntry[0];
+				
+				// Verify we have an arg we can match
+				String[] possibleArgs = {"a","t","p","b","e","k","before","since","id","-"}; // Removed "w", "r".
+				if(!Arrays.asList(possibleArgs).contains(arg_type) && !arg_type.startsWith("-")){
+					
+					// We support an alternate player syntax so that people can use the tab-complete
+					// feature of minecraft. Using p: prevents it.
+					Player autoFillPlayer = plugin.getServer().getPlayer(arg_type);
+					if( autoFillPlayer != null ){
+						MatchRule match = MatchRule.INCLUDE;
+						if(arg_type.startsWith("!")){
+							match = MatchRule.EXCLUDE;
+						}
+						parameters.addPlayerName( arg_type.replace("!", ""), match );
+					} else {
+						respond( sender, Prism.messenger.playerError( "Unrecognized parameter '"+arg+"' - Using only previous parameters. "+ChatColor.ITALIC+"Keep in mind that using parameter wands ignore radius and world parameters."+ChatColor.RED+" Use /prism ? for help.") );
+						parameters = new QueryParameters();
+						return false;
+					}
+				}
+				
+				// Verify no empty val
+				if(val.isEmpty()){
+					respond( sender, Prism.messenger.playerError("Can't use empty values for '"+arg+"' - Using only previous parameters. Use /prism ? for help.") );
+					return false;
+				}
+				
+				// Officially certify we found a valid argument and value!
+				if(Arrays.asList(possibleArgs).contains(arg_type)){
+					foundArgs.put(arg_type, val);
+					parameters.setFoundArgs(foundArgs);
+				}
+				
+				// Action
+				if(arg_type.equals("a")){
+					String[] actions = val.split(",");
+					if(actions.length > 0){
+						for(String action : actions){
+							// Find all actions that match the action provided - whether the full name or
+							// short name.
+							ArrayList<ActionType> actionTypes = Prism.getActionRegistry().getActionsByShortname( action.replace("!", "") );
+							if(!actionTypes.isEmpty()){
+								for(ActionType actionType : actionTypes){
+									
+									// Ensure the action allows this process type
+//									if( (processType.equals(PrismProcessType.ROLLBACK) && !actionType.canRollback()) || (processType.equals(PrismProcessType.RESTORE) && !actionType.canRestore()) ){
+										// @todo this is important information but is too spammy with a:place, because vehicle-place doesn't support a rollback etc
+//										respond( sender, Prism.messenger.playerError("Ingoring action '"+actionType.getName()+"' because it doesn't support rollbacks.") );
+//										continue;
+//									}
+									// Commented because we check for this later.
+									
+									// Check match type
+									MatchRule match = MatchRule.INCLUDE;
+									if(action.startsWith("!")){
+										match = MatchRule.EXCLUDE;
+									}
+									parameters.addActionType( actionType.getName(), match );
+								}
+							} else {
+								respond( sender, Prism.messenger.playerError("Ignoring action '"+action.replace("!", "")+"' because it's unrecognized. Did you mean '" + LevenshteinDistance.getClosestAction(action) +"'? Type '/prism params' for help.") );
+							}
+						}
+						// If none were valid, we end here.
+						if(parameters.getActionTypes().isEmpty()){
+							return false;
+						}
+					}
+				}
+				
+				// Player
+				if(arg_type.equals("p")){
+					String[] playerNames = val.split(",");
+					if(playerNames.length > 0){
+						for(String playerName : playerNames){
+							MatchRule match = MatchRule.INCLUDE;
+							if(playerName.startsWith("!")){
+								match = MatchRule.EXCLUDE;
+								playerName = playerName.replace("!", "");
+							}
+							else if(playerName.startsWith("~")){
+								match = MatchRule.PARTIAL;
+								playerName = playerName.replace("~", "");
+							}
+							parameters.addPlayerName( playerName, match );
+						}
+					}
+				}
+				
+				// Entity
+				if(arg_type.equals("e")){
+					String[] entityNames = val.split(",");
+					if(entityNames.length > 0){
+						for(String entityName : entityNames){
+							MatchRule match = MatchRule.INCLUDE;
+							if(entityName.startsWith("!")){
+								match = MatchRule.EXCLUDE;
+							}
+							parameters.addEntity( entityName.replace("!", ""), match );
+						}
+					}
+				}
+				
+				// Block
+				if(arg_type.equals("b")){
+					
+					String[] blocks = val.split(",");
+					
+					if(blocks.length > 0){
+						for(String b : blocks){
+					
+							// if user provided id:subid
+							if(b.contains(":") && b.length() >= 3){
+								String[] ids = b.split(":");
+								if(ids.length == 2 && TypeUtils.isNumeric(ids[0]) && TypeUtils.isNumeric(ids[1])){
+									parameters.addBlockFilter( Integer.parseInt( ids[0] ), Byte.parseByte( ids[1] ) );
+								} else {
+									respond( sender, Prism.messenger.playerError("Invalid block filter '"+val+"' - Using only previous parameters. Use /prism ? [command] for help.") );
+									return false;
+								}
+							} else {
+								
+								// It's id without a subid
+								if(TypeUtils.isNumeric(b)){
+									parameters.addBlockFilter( Integer.parseInt(b), (byte)0 );
+								} else {
+									
+									// Lookup the item name, get the ids
+									MaterialAliases items = plugin.getItems();
+									ArrayList<int[]> itemIds = items.getItemIdsByAlias( b );
+									if(itemIds.size() > 0){
+										for(int[] ids : itemIds){
+											if(ids.length == 2){
+												// If we really care about the sub id because it's a whole different item
+												if(BlockUtils.hasSubitems(ids[0])){
+													parameters.addBlockFilter( ids[0], (byte) ids[1] );
+												} else {
+													parameters.addBlockFilter( ids[0], (byte)0 );
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				
+				// Time
+				if(arg_type.equals("before")){
+					String date = PreprocessArgs.translateTimeStringToDate(plugin,sender,val);
+					if(date != null){
+						parameters.setBeforeTime( date );
+					} else {
+						return false;
+					}
+				}
+				if( arg_type.equals("since") || arg_type.equals("t") ){
+					String date = PreprocessArgs.translateTimeStringToDate(plugin,sender,val);
+					if(date != null){
+						parameters.setSinceTime( date );
+					} else {
+						return false;
+					}
+				}
+				
+				// Keyword
+				if(arg_type.equals("k")){
+					parameters.setKeyword( val );
+				}
+				
+				// ID
+				if(arg_type.equals("id")){
+					
+					if(TypeUtils.isNumeric( val )){
+						
+					} else {
+						respond( sender, Prism.messenger.playerError("ID must be a number - Using only previous parameters. Use /prism ? for help.") );
+						return false;
+					}
+					parameters.setId( Integer.parseInt(val) );
+				}
+				
+				// Special Flags
+				if(arg_type.startsWith("-")){
+					try {
+						String[] flagComponents = val.substring(1).split("=");
+						Flag flag = Flag.valueOf( flagComponents[0].replace("-", "_").toUpperCase() );
+						if(!(parameters.hasFlag(flag))){
+								
+							parameters.addFlag(flag);
+							
+							// Flag has a value
+							if( flagComponents.length > 1 ){
+								if(flag.equals(Flag.PER_PAGE)){
+									if(TypeUtils.isNumeric(flagComponents[1])){
+										parameters.setPerPage( Integer.parseInt(flagComponents[1]) );
+									} else {
+										respond( sender, Prism.messenger.playerError("Per-page flag value must be a number - Using only previous parameters. Use /prism ? for help.") );
+										return false;
+									}
+								}
+							}
+						}
+					} catch(IllegalArgumentException ex){
+						respond( sender, Prism.messenger.playerError("Unrecognized flag '"+val+"' - Using only previous parameters. Use /prism ? [command] for help.") );
+						return false;
+					}
+				}
+			}	
+		}
+		return true;
+	}
+	
+	/**
+	 * For use in {@link #setParameters(org.bukkit.entity.Player, java.lang.String[]) setParameters(...)}
+	 * @param sender
+	 * @param msg
+	 */
+	private static void respond( CommandSender sender, String msg ){
+		if(sender != null){
+			sender.sendMessage(msg);
+		} else {
+//			System.out.print(msg); // @todo let this output to console, is useful for db purge debugging
+		}
+	}
+	
+	/**
+	 * Get the {@link #parameters} set from {@link #setParameters}.
+	 * @return The wand's {@link me.botsko.prism.actionlibs.QueryParameters}.
+	 */
+	public QueryParameters getParameters(){
+		return parameters;
+	}
+}

--- a/src/main/java/me/botsko/prism/wands/QueryWandBase.java
+++ b/src/main/java/me/botsko/prism/wands/QueryWandBase.java
@@ -9,7 +9,6 @@ import me.botsko.prism.actionlibs.ActionType;
 import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
-import me.botsko.prism.bridge.WorldEditBridge;
 import me.botsko.prism.commandlibs.Flag;
 import me.botsko.prism.commandlibs.PreprocessArgs;
 import me.botsko.prism.utils.BlockUtils;

--- a/src/main/java/me/botsko/prism/wands/RestoreWand.java
+++ b/src/main/java/me/botsko/prism/wands/RestoreWand.java
@@ -1,6 +1,8 @@
 package me.botsko.prism.wands;
 
 import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -14,13 +16,9 @@ import me.botsko.prism.actionlibs.QueryResult;
 import me.botsko.prism.appliers.PrismApplierCallback;
 import me.botsko.prism.appliers.PrismProcessType;
 import me.botsko.prism.appliers.Restore;
+import org.bukkit.ChatColor;
 
-public class RestoreWand extends WandBase implements Wand {
-
-	/**
-	 * 
-	 */
-	private Prism plugin;
+public class RestoreWand extends QueryWandBase implements Wand {
 	
 	
 	/**
@@ -29,7 +27,7 @@ public class RestoreWand extends WandBase implements Wand {
 	 * @return 
 	 */
 	public RestoreWand(Prism plugin) {
-		this.plugin = plugin;
+		super(plugin);
 	}
 	
 	
@@ -63,7 +61,14 @@ public class RestoreWand extends WandBase implements Wand {
 		plugin.eventTimer.recordTimedEvent("rollback wand used");
 
 		// Build params
-		QueryParameters params = new QueryParameters();
+		QueryParameters params;
+		try {
+			params = parameters.clone();
+		} catch (CloneNotSupportedException ex) {
+			params = new QueryParameters();
+			player.sendMessage(Prism.messenger.playerError(ChatColor.YELLOW + "Warning: An error occurred while trying to retrieve the params from this wand. Checking with default parameters."));
+		}
+		
 		params.setWorld( player.getWorld().getName() );
 		params.setSpecificBlockLocation( block.getLocation());
 		params.setLimit(1);

--- a/src/main/java/me/botsko/prism/wands/RestoreWand.java
+++ b/src/main/java/me/botsko/prism/wands/RestoreWand.java
@@ -1,8 +1,6 @@
 package me.botsko.prism.wands;
 
 import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -73,12 +71,6 @@ public class RestoreWand extends QueryWandBase implements Wand {
 		params.setSpecificBlockLocation( block.getLocation());
 		params.setLimit(1);
 		params.setProcessType(PrismProcessType.RESTORE);
-		
-		// Append actions that can be restored
-		ArrayList<String> types = Prism.getActionRegistry().listActionsThatAllowRestore();
-		for(String type : types){
-			params.addActionType(type);
-		}
 		
 		ActionsQuery aq = new ActionsQuery(plugin);
 		QueryResult results = aq.lookup( params, player );

--- a/src/main/java/me/botsko/prism/wands/RollbackWand.java
+++ b/src/main/java/me/botsko/prism/wands/RollbackWand.java
@@ -76,12 +76,6 @@ public class RollbackWand extends QueryWandBase implements Wand{
 		params.setLimit(1);
 		params.setProcessType(PrismProcessType.ROLLBACK);
 		
-		// Append actions that can be rolled back
-		ArrayList<String> types = Prism.getActionRegistry().listActionsThatAllowRollback();
-		for(String type : types){
-			params.addActionType(type);
-		}
-		
 		ActionsQuery aq = new ActionsQuery(plugin);
 		QueryResult results = aq.lookup( params, player );
 		if(!results.getActionResults().isEmpty()){
@@ -98,13 +92,13 @@ public class RollbackWand extends QueryWandBase implements Wand{
 	 * 
 	 */
 	public void playerRightClick(Player player, Entity entity) {
-		return;
 	}
 
 
 	/**
 	 * 
 	 */
+	@Override
 	public void setItemWasGiven(boolean given) {
 		this.item_given = given;
 	}
@@ -113,6 +107,7 @@ public class RollbackWand extends QueryWandBase implements Wand{
 	/**
 	 * 
 	 */
+	@Override
 	public boolean itemWasGiven() {
 		return item_given;
 	}

--- a/src/main/java/me/botsko/prism/wands/RollbackWand.java
+++ b/src/main/java/me/botsko/prism/wands/RollbackWand.java
@@ -14,13 +14,9 @@ import me.botsko.prism.actionlibs.QueryResult;
 import me.botsko.prism.appliers.PrismApplierCallback;
 import me.botsko.prism.appliers.PrismProcessType;
 import me.botsko.prism.appliers.Rollback;
+import org.bukkit.ChatColor;
 
-public class RollbackWand extends WandBase implements Wand{
-
-	/**
-	 * 
-	 */
-	private Prism plugin;
+public class RollbackWand extends QueryWandBase implements Wand{
 
 	/**
 	 * 
@@ -34,7 +30,7 @@ public class RollbackWand extends WandBase implements Wand{
 	 * @return 
 	 */
 	public RollbackWand(Prism plugin) {
-		this.plugin = plugin;
+		super(plugin);
 	}
 	
 	
@@ -68,7 +64,13 @@ public class RollbackWand extends WandBase implements Wand{
 		plugin.eventTimer.recordTimedEvent("rollback wand used");
 
 		// Build params
-		QueryParameters params = new QueryParameters();
+		QueryParameters params;
+		try {
+			params = parameters.clone();
+		} catch (CloneNotSupportedException ex) {
+			params = new QueryParameters();
+			player.sendMessage(Prism.messenger.playerError(ChatColor.YELLOW + "Warning: An error occurred while trying to retrieve the params from this wand. Checking with default parameters."));
+		}
 		params.setWorld( player.getWorld().getName() );
 		params.setSpecificBlockLocation( block.getLocation());
 		params.setLimit(1);


### PR DESCRIPTION
... "/prism flags" uses the flags enum and doesn't go through them all separately. Allow players to share lookup results with other players and the console, bug 335.

Such as /prism i p:nasonfish t:10d
Or /prism wand rollback t:5m p:viveleroi
Or /prism wand inspect -extended
Or something.
And /prism lookup r:10 -share=nasonfish,viveleroi,console
