### PR TITLE
Allow admins to remove branding and assurance messages.

### DIFF
--- a/prism.iml
+++ b/prism.iml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="bukkit-1.5.1-R0.1-20130321.193246-5" level="project" />
+    <orderEntry type="library" name="Maven: me.botsko:elixr:1.0-dev-17-g62eb894-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.bukkit:bukkit:1.5.1-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: org.bukkit:craftbukkit:1.5.1-R0.1-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: com.sk89q:worldedit:5.5.5-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: de.schlichtherle:truezip:6.8.3" level="project" />
+    <orderEntry type="library" name="Maven: rhino:js:1.7R2" level="project" />
+    <orderEntry type="library" name="Maven: com.sk89q:jchronic:0.2.4a" level="project" />
+    <orderEntry type="library" name="Maven: junit:junit:4.8.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.tomcat:com.springsource.org.apache.tomcat.jdbc:1.0.9.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.juli:com.springsource.org.apache.juli.extras:6.0.24" level="project" />
+    <orderEntry type="library" name="Maven: org.dthielke:Herochat:5.6.5" level="project" />
+  </component>
+</module>
+

--- a/src/main/java/me/botsko/prism/Messenger.java
+++ b/src/main/java/me/botsko/prism/Messenger.java
@@ -8,6 +8,8 @@ public class Messenger {
 	 * 
 	 */
 	protected String plugin_name;
+
+    protected Prism prism;
 	
 	
 	/**
@@ -17,7 +19,6 @@ public class Messenger {
 	public Messenger( String plugin_name ){
 		this.plugin_name = plugin_name;
 	}
-	
 
 	/**
 	 * 
@@ -26,7 +27,7 @@ public class Messenger {
 	 */
 	public String playerHeaderMsg(String msg){
 		if(msg != null){
-			return ChatColor.LIGHT_PURPLE + plugin_name+" // " + ChatColor.WHITE + msg;
+			return (prism.getConfig().getBoolean("prism.messages.branding", true) ? ChatColor.LIGHT_PURPLE + plugin_name + " // " : null) + ChatColor.WHITE + msg;
 		}
 		return "";
 	}
@@ -39,7 +40,7 @@ public class Messenger {
 	 */
 	public String playerSubduedHeaderMsg(String msg){
 		if(msg != null){
-			return ChatColor.LIGHT_PURPLE + plugin_name+" // " + ChatColor.GRAY + msg;
+			return (prism.getConfig().getBoolean("prism.messages.branding", true) ? ChatColor.LIGHT_PURPLE + plugin_name + " // " : null) + ChatColor.GRAY + msg;
 		}
 		return "";
 	}
@@ -91,7 +92,7 @@ public class Messenger {
 	 */
 	public String playerError(String msg){
 		if(msg != null){
-			return ChatColor.LIGHT_PURPLE + plugin_name+" // " + ChatColor.RED + msg;
+			return (prism.getConfig().getBoolean("prism.messages.branding", true) ? ChatColor.LIGHT_PURPLE + plugin_name + " // " : null) + ChatColor.RED + msg;
 		}
 		return "";
 	}

--- a/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/src/main/java/me/botsko/prism/PrismConfig.java
@@ -32,6 +32,10 @@ public class PrismConfig extends ConfigBase {
 		
 		config.addDefault("prism.notify-newer-versions", true);
 		config.addDefault("prism.allow-metrics", true);
+
+        // Messages
+        config.addDefault("prism.messages.branding", true);
+        config.addDefault("prism.messages.assurances", true);
 			
 		// Database
 		config.addDefault("prism.database.mode", "mysql"); // sqlite or mysql

--- a/src/main/java/me/botsko/prism/appliers/Preview.java
+++ b/src/main/java/me/botsko/prism/appliers/Preview.java
@@ -145,7 +145,7 @@ public class Preview implements Previewable {
 				player.sendBlockChange(u.getOriginalBlock().getLocation(), u.getOriginalBlock().getTypeId(), u.getOriginalBlock().getRawData());
 			}
 		}
-		sender.sendMessage( Prism.messenger.playerHeaderMsg( "Preview canceled." + ChatColor.GRAY + " Please come again!" ) );
+		sender.sendMessage( Prism.messenger.playerHeaderMsg( "Preview canceled." + (plugin.getConfig().getBoolean("prism.messages.assurances", true) ? ChatColor.GRAY + " Please come again!" : null)) );
 	}
 	
 	

--- a/src/main/java/me/botsko/prism/appliers/PrismApplierCallback.java
+++ b/src/main/java/me/botsko/prism/appliers/PrismApplierCallback.java
@@ -12,7 +12,8 @@ import org.bukkit.entity.Player;
 
 public class PrismApplierCallback implements ApplierCallback {
 	
-	
+	protected Prism prism;
+
 	/**
 	 * 
 	 */
@@ -39,7 +40,7 @@ public class PrismApplierCallback implements ApplierCallback {
 				if(result.getChangesSkipped() > 0){
 					msg += " " + result.getChangesSkipped() + " skipped.";
 				}
-				if(result.getChangesApplied() > 0){
+				if(result.getChangesApplied() > 0 && prism.getConfig().getBoolean("prism.messages.assurances", true)){
 					msg += ChatColor.GRAY + " It's like it never happened.";
 				}
 				sender.sendMessage( Prism.messenger.playerHeaderMsg( msg ) );
@@ -73,7 +74,7 @@ public class PrismApplierCallback implements ApplierCallback {
 				if(result.getChangesSkipped() > 0){
 					msg += " " + result.getChangesSkipped() + " skipped.";
 				}
-				if(result.getChangesApplied() > 0){
+				if(result.getChangesApplied() > 0 && prism.getConfig().getBoolean("prism.messages.assurances", true)){
 					msg += ChatColor.GRAY + " It's like it was always there.";
 				}
 				sender.sendMessage( Prism.messenger.playerHeaderMsg( msg ) );
@@ -106,7 +107,7 @@ public class PrismApplierCallback implements ApplierCallback {
 			if(result.getChangesSkipped() > 0){
 				msg += " " + result.getChangesSkipped() + " skipped.";
 			}
-			if(result.getChangesApplied() > 0){
+			if(result.getChangesApplied() > 0 && prism.getConfig().getBoolean("prism.messages.assurances", true)){
 				msg += ChatColor.GRAY + " If anyone asks, you never did that.";
 			}
 			sender.sendMessage( Prism.messenger.playerHeaderMsg( msg ) );

--- a/src/main/java/me/botsko/prism/appliers/Rollback.java
+++ b/src/main/java/me/botsko/prism/appliers/Rollback.java
@@ -15,7 +15,8 @@ import me.botsko.prism.utils.BlockUtils;
 import me.botsko.prism.utils.EntityUtils;
 
 public class Rollback extends Preview {
-	
+
+    protected Prism prism;
 	
 	/**
 	 * 
@@ -47,7 +48,7 @@ public class Rollback extends Preview {
 			if( !parameters.hasFlag(Flag.NO_EXT) ){
 				ArrayList<BlockStateChange> blockStateChanges = BlockUtils.extinguish(player.getLocation(),parameters.getRadius());
 				if( blockStateChanges != null && !blockStateChanges.isEmpty() ){
-					player.sendMessage( Prism.messenger.playerHeaderMsg("Extinguishing fire!" + ChatColor.GRAY + " Like a boss.") );
+					player.sendMessage( Prism.messenger.playerHeaderMsg("Extinguishing fire!" + (prism.getConfig().getBoolean("prism.messages.assurances", true) ? ChatColor.GRAY + " Like a boss." : null)) );
 				}
 			}
 		}
@@ -57,7 +58,7 @@ public class Rollback extends Preview {
 			if( !parameters.hasFlag(Flag.NO_ITEMCLEAR) ){
 				int removed = EntityUtils.removeNearbyItemDrops(player, parameters.getRadius());
 				if(removed > 0){
-					player.sendMessage( Prism.messenger.playerHeaderMsg("Removed " + removed + " drops in affected area." + ChatColor.GRAY + " Like a boss.") );
+					player.sendMessage( Prism.messenger.playerHeaderMsg("Removed " + removed + " drops in affected area." + (prism.getConfig().getBoolean("prism.messages.assurances", true) ? ChatColor.GRAY + " Like a boss." : null)) );
 				}
 			}
 		}
@@ -74,7 +75,7 @@ public class Rollback extends Preview {
 			drained = BlockUtils.drainwater(player.getLocation(),parameters.getRadius());
 		}
 		if(drained != null && drained.size() > 0){
-			player.sendMessage( Prism.messenger.playerHeaderMsg("Draining liquid!" + ChatColor.GRAY + " Like a boss.") );
+			player.sendMessage( Prism.messenger.playerHeaderMsg("Draining liquid!" + (prism.getConfig().getBoolean("prism.messages.assurances", true) ? ChatColor.GRAY + " Like a boss." : null)) );
 		}
 			
 		// Give the results to the changequeue

--- a/src/main/java/me/botsko/prism/commands/HelpCommand.java
+++ b/src/main/java/me/botsko/prism/commands/HelpCommand.java
@@ -24,7 +24,7 @@ public class HelpCommand implements SubHandler {
 	 */
 	protected void help( CommandSender sender ){
 		
-		sender.sendMessage( Prism.messenger.playerHeaderMsg( ChatColor.GOLD + "--- Basic Usage ---" ) );
+		sender.sendMessage( Prism.messenger.playerHeaderMsg( ChatColor.GOLD + "--- Prism: Basic Usage ---" ) );
 		
 		sender.sendMessage( Prism.messenger.playerHelp("i", "Toggles the inspector wand."));
 		sender.sendMessage( Prism.messenger.playerHelp("(l|lookup) (params)", "Search the database"));


### PR DESCRIPTION
Thanks to GitHub's general stupidity, I've been forced to open a new pull request with the correct branch and fixed issues.

Please view the fixed version of this PR [here](https://github.com/prism/Prism/pull/22).
