### PR TITLE
Fixed empty player field when the block was broken by an enderdragon or ghast fireball. bug 350:resolved

### DIFF
--- a/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/src/main/java/me/botsko/prism/PrismConfig.java
@@ -127,6 +127,7 @@ public class PrismConfig extends ConfigBase {
 		config.addDefault("prism.tracking.craft-item", false);
 		config.addDefault("prism.tracking.creeper-explode", true);
 		config.addDefault("prism.tracking.crop-trample", true);
+		config.addDefault("prism.tracking.dragon-eat", true);
 		config.addDefault("prism.tracking.enchant-item", false);
 		config.addDefault("prism.tracking.enderman-pickup", true);
 		config.addDefault("prism.tracking.enderman-place", true);

--- a/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
@@ -161,6 +161,7 @@ public class ActionRegistry {
 		registerAction( new ActionType( "craft-item", false, false, false, "ItemStackAction", "crafted") );
 		registerAction( new ActionType( "creeper-explode", false, true, true, "BlockAction", "blew up") );
 		registerAction( new ActionType( "crop-trample", false, true, true, "BlockAction", "trampled") );
+		registerAction( new ActionType( "dragon-eat", false, true, true, "BlockAction", "ate" ) );
 		registerAction( new ActionType( "enchant-item", false, false, false, "ItemStackAction", "enchanted") );
 		registerAction( new ActionType( "enderman-pickup", false, true, true, "BlockAction", "picked up") );
 		registerAction( new ActionType( "enderman-place", true, true, true, "BlockAction", "placed") );

--- a/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
@@ -12,6 +12,7 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Creeper;
+import org.bukkit.entity.EnderDragon;
 import org.bukkit.entity.Enderman;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -365,7 +366,6 @@ public class PrismEntityEvents implements Listener {
 		String name;
 		String action = "entity-explode";
 		if(event.getEntity() != null){
-			name = "";
 			if(event.getEntity() instanceof Creeper){
 				if( !Prism.getIgnore().event("creeper-explode",event.getEntity().getWorld()) ) return;
 				action = "creeper-explode";
@@ -375,6 +375,14 @@ public class PrismEntityEvents implements Listener {
 				if( !Prism.getIgnore().event("tnt-explode",event.getEntity().getWorld()) ) return;
 				action = "tnt-explode";
 				name = "tnt";
+			} else if(event.getEntity() instanceof EnderDragon){
+				if( !Prism.getIgnore().event("dragon-eat", event.getEntity().getWorld()) ) return;
+				action = "dragon-eat";
+				name = "enderdragon";
+			} else {
+				if( !Prism.getIgnore().event("entity-explode", event.getLocation().getWorld()) ) return;
+				name = event.getEntity().getType().getName().replace("_", " ");
+				name = name.length() > 15 ? name.substring(0, 15) : name; // I don't think this can happen, but just in case. Might look weird, but that's better than breaking stuff.
 			}
 		} else {
 			if( !Prism.getIgnore().event("entity-explode", event.getLocation().getWorld()) ) return;


### PR DESCRIPTION
dragon-eat means the dragon is eating blocks.
Any other entities that break blocks and somehow trigger the entity-explode event will also have their name there.
