### PR TITLE
Added Postgres Support. Requires 9.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,23 @@
 		</repository>
 	</repositories>
 	<build>
-		<plugins>
-			<plugin>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>2.0</version>

--- a/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/src/main/java/me/botsko/prism/PrismConfig.java
@@ -50,6 +50,13 @@ public class PrismConfig extends ConfigBase {
 		config.addDefault("prism.mysql.database", "minecraft");
 		config.addDefault("prism.mysql.port", "3306");
 		
+		// PostgreSQL
+		config.addDefault("prism.postgresql.hostname", "127.0.0.1");
+		config.addDefault("prism.postgresql.username", "prism");
+		config.addDefault("prism.postgresql.password", "");
+		config.addDefault("prism.postgresql.database", "minecraft");
+		config.addDefault("prism.postgresql.port", "5432");
+		
 		// Sqlite
 		config.addDefault("prism.sqlite.enable-delete-limit", false);
 		
@@ -239,7 +246,7 @@ public class PrismConfig extends ConfigBase {
 		config.addDefault("prism.alerts.uses.log-to-console", true);
 		config.addDefault("prism.alerts.uses.lighter", true);
 		config.addDefault("prism.alerts.uses.lava", true);
-		
+
 		List<String> monitorItems = new ArrayList<String>();
 		monitorItems.add("7");
 		monitorItems.add("29");

--- a/src/main/java/me/botsko/prism/actionlibs/QueryBuilder.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryBuilder.java
@@ -97,7 +97,10 @@ public class QueryBuilder {
 				columns.add("DATE_FORMAT("+tableName+".action_time, '%c/%e/%y') AS display_date");
 				columns.add("DATE_FORMAT("+tableName+".action_time, '%l:%i:%s%p') AS display_time");
 			}
-			
+			else if( dbMode.equalsIgnoreCase("postgresql") ){
+				columns.add("TO_CHAR("+tableName+".action_time, 'FMMM/FMDD/YYYY') AS display_date");
+				columns.add("TO_CHAR("+tableName+".action_time, 'FMHH12:MI:SSam') AS display_time");
+			}
 			if( shouldGroup ){
 				columns.add("COUNT(*) counted");
 			}
@@ -271,6 +274,9 @@ public class QueryBuilder {
 				// Do it! Or not...
 				if( shouldGroup ){
 					query += " GROUP BY "+tableName+".action_type, "+tableName+".player, "+tableName+".block_id, "+tableName+".data";
+					if ( dbMode.equals("postgresql")) {
+						query += ", "+tableName+".id";
+					}
 				}
 			
 				/**

--- a/src/main/java/me/botsko/prism/settings/Settings.java
+++ b/src/main/java/me/botsko/prism/settings/Settings.java
@@ -134,7 +134,7 @@ public class Settings {
 			}
 
 			conn = Prism.dbc();
-    		s = conn.prepareStatement ("SELECT v FROM prism_meta WHERE k = ? LIMIT 0,1");
+    		s = conn.prepareStatement ("SELECT v FROM prism_meta WHERE k = ? LIMIT 1");
     		s.setString(1, finalKey);
     		rs = s.executeQuery();
 


### PR DESCRIPTION
This adds support for Postgresql databases.  Minimum version 9.1 required.

This has only had basic testing, in which it was able to record and look up block breaks.  the actual SQL changes are very minimal and mostly related to table/index creation and column quoting. also a fix for postgres' more strict group by syntax, which, as far as I can tell, could be safely merged into the mysql version of the query, but I didn't want to modify that without reason.
