### PR TITLE
Fix result indexing by page

### DIFF
--- a/src/main/java/me/botsko/prism/actionlibs/QueryResult.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryResult.java
@@ -155,7 +155,7 @@ public class QueryResult {
 	 */
 	public int getIndexOfFirstResult(){
 		int index = (page * per_page)-per_page;
-		return (index == 0 ? 1 : index);
+		return index + 1;
 	}
 
 	


### PR DESCRIPTION
Previously results after the first page were off by one

For example:

/pr l a:chat
/pr page 1 ---- shows results numbered 1-5
/pr page 2 ---- show results numbered 5-9 instead of 6-10
