### PR TITLE
Fix material names having underscores with the inspector wand.

### DIFF
--- a/src/main/java/me/botsko/prism/wands/InspectorWand.java
+++ b/src/main/java/me/botsko/prism/wands/InspectorWand.java
@@ -113,7 +113,7 @@ public class InspectorWand extends QueryWandBase implements Wand {
 						player.sendMessage( Prism.messenger.playerMsg( am.getMessage() ) );
 					}
 				} else {
-					String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().toLowerCase() + " block");
+					String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().replaceAll("_", " ").toLowerCase() + (block.getType().toString().endsWith("block") ? "" : " block"));
 					player.sendMessage( Prism.messenger.playerError( "No history for this " + space_name + " found." ) );
 				}
 			}


### PR DESCRIPTION
At the moment, if an inspected block has no results, the material name still has underscores, and the word "block" is inserted regardless of whether the material type ends with "block":

![screen shot 2013-06-17 at 10 59 57](https://f.cloud.github.com/assets/1849924/660869/9e8de378-d71b-11e2-9031-f08fe838dbda.png)

This PR stops both of those things from happening by changing the following line in `InspectorWand.java` from this...:

``` java
String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().toLowerCase() + " block");
```

to this...:

``` java
String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().replaceAll("_", " ").toLowerCase() + (block.getType().toString().endsWith("block") ? "" : " block"));
```
