### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/main/java/me/botsko/prism/ConfigBase.java
+++ b/src/main/java/me/botsko/prism/ConfigBase.java
@@ -33,8 +33,7 @@ public class ConfigBase {
 	
 	
 	/**
-	 * 
-	 * @param plugin
+	 *
 	 */
 	public FileConfiguration getConfig(){
 		config = plugin.getConfig();
@@ -82,7 +81,8 @@ public class ConfigBase {
 	
 	/**
 	 * 
-	 * @param player
+	 * @param default_folder
+     * @param filename
 	 * @return
 	 */
 	protected FileConfiguration loadConfig( String default_folder, String filename ){

--- a/src/main/java/me/botsko/prism/Language.java
+++ b/src/main/java/me/botsko/prism/Language.java
@@ -15,7 +15,7 @@ public class Language {
 	
 	/**
 	 * 
-	 * @param plugin
+	 * @param lang
 	 */
 	public Language( FileConfiguration lang ) {
 		this.lang = lang;

--- a/src/main/java/me/botsko/prism/Messenger.java
+++ b/src/main/java/me/botsko/prism/Messenger.java
@@ -74,8 +74,7 @@ public class Messenger {
 
 	
 	/**
-	 * 
-	 * @param player_name
+	 *
 	 * @param cmd
 	 * @param help
 	 */

--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -762,8 +762,7 @@ public class Prism extends JavaPlugin {
 
 	
 	/**
-	 * 
-	 * @param msg
+	 *
 	 * @return
 	 */
 	public String msgMissingArguments() {
@@ -772,8 +771,7 @@ public class Prism extends JavaPlugin {
 
 	
 	/**
-	 * 
-	 * @param msg
+	 *
 	 * @return
 	 */
 	public String msgInvalidArguments() {
@@ -782,8 +780,7 @@ public class Prism extends JavaPlugin {
 
 	
 	/**
-	 * 
-	 * @param msg
+	 *
 	 * @return
 	 */
 	public String msgInvalidSubcommand() {
@@ -792,8 +789,7 @@ public class Prism extends JavaPlugin {
 
 	
 	/**
-	 * 
-	 * @param msg
+	 *
 	 * @return
 	 */
 	public String msgNoPermission() {
@@ -833,7 +829,7 @@ public class Prism extends JavaPlugin {
 
 	/**
 	 * 
-	 * @param message
+	 * @param messages
 	 */
 	public static void logSection(String[] messages) {
 		if (messages.length > 0) {
@@ -859,7 +855,7 @@ public class Prism extends JavaPlugin {
 
 	/**
 	 * 
-	 * @param message
+	 * @param loc
 	 */
 	public static void debug(Location loc) {
 		debug("Location: " + loc.getBlockX() + " " + loc.getBlockY() + " " + loc.getBlockZ());

--- a/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/src/main/java/me/botsko/prism/PrismConfig.java
@@ -20,8 +20,7 @@ public class PrismConfig extends ConfigBase {
 	
 
 	/**
-	 * 
-	 * @param plugin
+	 *
 	 */
 	public FileConfiguration getConfig(){
 		

--- a/src/main/java/me/botsko/prism/Updater.java
+++ b/src/main/java/me/botsko/prism/Updater.java
@@ -32,8 +32,6 @@ public class Updater {
 	
 	/**
 	 * Get the current database schema version
-	 * @param person
-	 * @param account_name
 	 */
 	protected int getClientDbSchemaVersion(){
 		String schema_ver = Settings.getSetting("schema_ver");

--- a/src/main/java/me/botsko/prism/actionlibs/ActionFactory.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionFactory.java
@@ -37,7 +37,6 @@ public class ActionFactory {
 	/**
 	 * GenericAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, String player ){
@@ -66,7 +65,6 @@ public class ActionFactory {
 	/**
 	 * BlockChangeAction | WorldeditAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, Location loc, int oldId, byte oldSubid, int newId, byte newSubid, String player ){
@@ -85,7 +83,6 @@ public class ActionFactory {
 	/**
 	 * BlockShiftAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, Block from, Location to, String player ){
@@ -101,7 +98,6 @@ public class ActionFactory {
 	/**
 	 * EntityAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create(String action_type, Entity entity, String player ){
@@ -119,8 +115,6 @@ public class ActionFactory {
 	/**
 	 * EntityTravelAction
 	 * @param action_type
-	 * @param block
-	 * @param player
 	 */
 	public static Handler create( String action_type, Entity entity, Location from, Location to, TeleportCause cause ){
 		EntityTravelAction a = new EntityTravelAction();
@@ -135,7 +129,6 @@ public class ActionFactory {
 	/**
 	 * GrowAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, BlockState blockstate, String player ){
@@ -150,7 +143,6 @@ public class ActionFactory {
 	/**
 	 * HangingItemAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, Hanging hanging, String player ){
@@ -165,7 +157,6 @@ public class ActionFactory {
 	/**
 	 * ItemStackAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, ItemStack item, Map<Enchantment,Integer> enchantments, Location loc, String player ){
@@ -184,7 +175,6 @@ public class ActionFactory {
 	/**
 	 * PlayerAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, Player player, String additionalInfo ){
@@ -200,7 +190,6 @@ public class ActionFactory {
 	/**
 	 * PlayerDeathAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, Player player, String cause, String attacker ){
@@ -217,7 +206,6 @@ public class ActionFactory {
 	/**
 	 * PrismProcessActionData
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, PrismProcessType processType, Player player, String parameters ){
@@ -233,7 +221,6 @@ public class ActionFactory {
 	/**
 	 * PrismRollbackAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, BlockState oldblock, BlockState newBlock, String player, int parent_id ){
@@ -280,7 +267,6 @@ public class ActionFactory {
 	/**
 	 * VehicleAction
 	 * @param action_type
-	 * @param block
 	 * @param player
 	 */
 	public static Handler create( String action_type, Vehicle vehicle, String player ){

--- a/src/main/java/me/botsko/prism/actionlibs/ActionMessage.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionMessage.java
@@ -126,8 +126,7 @@ public class ActionMessage {
 	
 	
 	/**
-	 * 
-	 * @param type
+	 *
 	 * @return
 	 */
 	protected String getPosNegPrefix(){

--- a/src/main/java/me/botsko/prism/actionlibs/ActionRecorder.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionRecorder.java
@@ -133,8 +133,7 @@ public class ActionRecorder implements Runnable {
 	
 	
 	/**
-	 * 
-	 * @param entities
+	 *
 	 * @throws SQLException
 	 */
 	public void insertActionsIntoDatabase() {

--- a/src/main/java/me/botsko/prism/actionlibs/ActionType.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionType.java
@@ -26,7 +26,8 @@ public class ActionType {
 	
 	/**
 	 * 
-	 * @param actionTypeName
+	 * @param name
+     * @param doesCreateBlock
 	 * @param canRollback
 	 * @param canRestore
 	 * @param niceDescription

--- a/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
@@ -184,8 +184,7 @@ public class ActionsQuery {
 	
 	/**
 	 * 
-	 * @param person
-	 * @param account_name
+	 * @param playername
 	 */
 	public int getUsersLastPrismProcessId( String playername ){
 		int id = 0;
@@ -217,8 +216,7 @@ public class ActionsQuery {
 	
 	/**
 	 * 
-	 * @param person
-	 * @param account_name
+	 * @param id
 	 */
 	public PrismProcessAction getPrismProcessRecord( int id ){
 		PrismProcessAction process = null;

--- a/src/main/java/me/botsko/prism/actionlibs/HandlerRegistry.java
+++ b/src/main/java/me/botsko/prism/actionlibs/HandlerRegistry.java
@@ -43,8 +43,7 @@ public class HandlerRegistry<H> {
 	
 	/**
 	 * Register a new action type for event recording, lookups, etc.
-	 * @param <H>
-	 * @param actionType
+	 * @param handlerClass
 	 */
 	protected void registerHandler( Class<? extends Handler> handlerClass ){
 		String[] names = handlerClass.getName().split("\\.");
@@ -56,7 +55,8 @@ public class HandlerRegistry<H> {
 	
 	/**
 	 * Register a new action type for event recording, lookups, etc.
-	 * @param actionType
+	 * @param apiPlugin
+     * @param handlerClass
 	 * @throws InvalidActionException 
 	 */
 	public void registerCustomHandler( Plugin apiPlugin, Class<? extends Handler> handlerClass ) throws InvalidActionException{

--- a/src/main/java/me/botsko/prism/actionlibs/Ignore.java
+++ b/src/main/java/me/botsko/prism/actionlibs/Ignore.java
@@ -48,7 +48,7 @@ public class Ignore {
 	
 	/**
 	 * 
-	 * @param a
+	 * @param actionTypeName
 	 * @return
 	 */
 	public boolean event( String actionTypeName ){
@@ -70,7 +70,9 @@ public class Ignore {
 	
 	/**
 	 * 
-	 * @param a
+	 * @param actionTypeName
+     * @param world
+     * @param player
 	 * @return
 	 */
 	public boolean event( String actionTypeName, World world, String player ){
@@ -86,7 +88,8 @@ public class Ignore {
 	
 	/**
 	 * 
-	 * @param a
+	 * @param actionTypeName
+     * @param player
 	 * @return
 	 */
 	public boolean event( String actionTypeName, Player player ){
@@ -130,7 +133,8 @@ public class Ignore {
 	
 	/**
 	 * 
-	 * @param a
+	 * @param actionTypeName
+     * @param block
 	 * @return
 	 */
 	public boolean event( String actionTypeName, Block block ){
@@ -146,7 +150,8 @@ public class Ignore {
 	
 	/**
 	 * 
-	 * @param a
+	 * @param actionTypeName
+     * @param world
 	 * @return
 	 */
 	public boolean event( String actionTypeName, World world ){

--- a/src/main/java/me/botsko/prism/actionlibs/QueryBuilder.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryBuilder.java
@@ -46,8 +46,8 @@ public class QueryBuilder {
 	
 	/**
 	 * 
-	 * @param plugin
 	 * @param parameters
+	 * @param shouldGroup
 	 * @return
 	 */
 	public String buildQuery( QueryParameters parameters, boolean shouldGroup ){
@@ -409,8 +409,8 @@ public class QueryBuilder {
 	
 	/**
 	 * 
-	 * @param arg_values
-	 * @param player_name
+	 * @param minLoc
+     * @param maxLoc
 	 * @return
 	 */
 	protected void buildRadiusCondition( Vector minLoc, Vector maxLoc ){

--- a/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
@@ -112,7 +112,7 @@ public class QueryParameters implements Cloneable {
 	
 	
 	/**
-	 * @param block the block to set
+	 * @param id the block to set
 	 */
 	public void addBlockFilter( int id, byte data ) {
 		this.block_filters.put(id,data);
@@ -291,7 +291,7 @@ public class QueryParameters implements Cloneable {
 	
 	
 	/**
-	 * @param world the world to set
+	 * @param keyword the world to set
 	 */
 	public void setKeyword(String keyword) {
 		this.keyword = keyword;
@@ -436,8 +436,7 @@ public class QueryParameters implements Cloneable {
 	
 	
 	/**
-	 * 
-	 * @param id
+	 *
 	 */
 	public int getParentId(){
 		return parent_id;
@@ -550,7 +549,7 @@ public class QueryParameters implements Cloneable {
 	
 	/**
 	 * Set the players you're sharing the lookup with.
-	 * @param players 
+	 * @param sender
 	 */
 	public void addSharedPlayer(CommandSender sender){
 		this.shared_players.add(sender);
@@ -569,7 +568,7 @@ public class QueryParameters implements Cloneable {
 
 	/**
 	 * Ignore the time.
-	 * @param b 
+	 * @param ignore
 	 */
 	public void setIgnoreTime(boolean ignore) {
 		this.ignoreTime = ignore;

--- a/src/main/java/me/botsko/prism/actions/BlockShiftAction.java
+++ b/src/main/java/me/botsko/prism/actions/BlockShiftAction.java
@@ -19,9 +19,7 @@ public class BlockShiftAction extends GenericAction {
 	
 	/**
 	 * 
-	 * @param action_type
-	 * @param block
-	 * @param player
+	 * @param from
 	 */
 	public void setBlock( Block from ){
 		

--- a/src/main/java/me/botsko/prism/actions/EntityAction.java
+++ b/src/main/java/me/botsko/prism/actions/EntityAction.java
@@ -40,9 +40,8 @@ public class EntityAction extends GenericAction {
 
 	/**
 	 * 
-	 * @param action_type
-	 * @param block
-	 * @param player
+	 * @param entity
+     * @param dyeUsed
 	 */
 	public void setEntity( Entity entity, String dyeUsed ){
 		

--- a/src/main/java/me/botsko/prism/actions/EntityTravelAction.java
+++ b/src/main/java/me/botsko/prism/actions/EntityTravelAction.java
@@ -22,10 +22,7 @@ public class EntityTravelAction extends GenericAction {
 
 
 	/**
-	 * 
-	 * @param action_type
-	 * @param block
-	 * @param player
+	 *
 	 */
 	public EntityTravelAction( ){
 		actionData = new EntityTravelActionData();

--- a/src/main/java/me/botsko/prism/actions/GrowAction.java
+++ b/src/main/java/me/botsko/prism/actions/GrowAction.java
@@ -7,9 +7,7 @@ public class GrowAction extends BlockAction {
 	
 	/**
 	 * 
-	 * @param action_type
-	 * @param block_filters
-	 * @param player
+	 * @param blockstate
 	 */
 	public void setBlock( BlockState blockstate ){
 		if(blockstate != null){

--- a/src/main/java/me/botsko/prism/actions/Handler.java
+++ b/src/main/java/me/botsko/prism/actions/Handler.java
@@ -207,15 +207,14 @@ public interface Handler {
 	
 	
 	/**
-	 * 
-	 * @param pl
+	 *
 	 */
 	public abstract boolean isCanceled();
 	
 	
 	/**
 	 * 
-	 * @param pl
+	 * @param cancel
 	 */
 	public abstract void setCanceled( boolean cancel );
 	

--- a/src/main/java/me/botsko/prism/actions/HangingItemAction.java
+++ b/src/main/java/me/botsko/prism/actions/HangingItemAction.java
@@ -27,9 +27,7 @@ public class HangingItemAction extends GenericAction {
 
 	/**
 	 * 
-	 * @param action_type
-	 * @param block
-	 * @param player
+	 * @param hanging
 	 */
 	public void setHanging( Hanging hanging ){
 		

--- a/src/main/java/me/botsko/prism/actions/PrismProcessAction.java
+++ b/src/main/java/me/botsko/prism/actions/PrismProcessAction.java
@@ -19,9 +19,8 @@ public class PrismProcessAction extends GenericAction {
 	
 	/**
 	 * 
-	 * @param action_type
-	 * @param block
-	 * @param player
+	 * @param processType
+     * @param parameters
 	 */
 	public void setProcessData( PrismProcessType processType, String parameters ){
 		

--- a/src/main/java/me/botsko/prism/actions/PrismRollbackAction.java
+++ b/src/main/java/me/botsko/prism/actions/PrismRollbackAction.java
@@ -8,9 +8,9 @@ public class PrismRollbackAction extends BlockChangeAction {
 	
 	/**
 	 * 
-	 * @param action_type
-	 * @param block
-	 * @param player
+	 * @param oldblock
+     * @param newBlock
+     * @param parent_id
 	 */
 	public void setBlockChange(  BlockState oldblock, BlockState newBlock, int parent_id ){
 		this.data = ""+parent_id;

--- a/src/main/java/me/botsko/prism/actions/SignAction.java
+++ b/src/main/java/me/botsko/prism/actions/SignAction.java
@@ -33,9 +33,8 @@ public class SignAction extends GenericAction {
 	
 	/**
 	 * 
-	 * @param action_type
 	 * @param block
-	 * @param player
+	 * @param lines
 	 */
 	public void setBlock( Block block, String[] lines ){
 		

--- a/src/main/java/me/botsko/prism/appliers/ApplierResult.java
+++ b/src/main/java/me/botsko/prism/appliers/ApplierResult.java
@@ -50,7 +50,10 @@ public class ApplierResult {
 	 * 
 	 * @param changes_applied
 	 * @param changes_skipped
-	 * @param messages
+	 * @param changes_planned
+     * @param blockStateChanges
+     * @param params
+     * @param entities_moved
 	 */
 	public ApplierResult( boolean is_preview, int changes_applied, int changes_skipped, int changes_planned, ArrayList<BlockStateChange> blockStateChanges, QueryParameters params, HashMap<Entity,Integer> entities_moved ){
 		this.changes_applied = changes_applied;

--- a/src/main/java/me/botsko/prism/appliers/ChangeResult.java
+++ b/src/main/java/me/botsko/prism/appliers/ChangeResult.java
@@ -18,7 +18,6 @@ public class ChangeResult {
 	/**
 	 * 
 	 * @param changeResultType
-	 * @param blockStateChange
 	 */
 	public ChangeResult( ChangeResultType changeResultType ){
 		this(changeResultType, null);

--- a/src/main/java/me/botsko/prism/appliers/PreviewSession.java
+++ b/src/main/java/me/botsko/prism/appliers/PreviewSession.java
@@ -24,8 +24,7 @@ public class PreviewSession {
 	/**
 	 * 
 	 * @param player
-	 * @param undo
-	 * @param args
+	 * @param previewer
 	 */
 	public PreviewSession( Player player, Previewable previewer ){
 		this.player = player;

--- a/src/main/java/me/botsko/prism/appliers/PrismApplierCallback.java
+++ b/src/main/java/me/botsko/prism/appliers/PrismApplierCallback.java
@@ -102,7 +102,7 @@ public class PrismApplierCallback implements ApplierCallback {
 		if(result.getProcessType().equals(PrismProcessType.UNDO)){
 				
 			// Build the results message
-			String msg = result.getChangesApplied() + " things neverminded.";
+			String msg = result.getChangesApplied() + " changes undone.";
 			if(result.getChangesSkipped() > 0){
 				msg += " " + result.getChangesSkipped() + " skipped.";
 			}

--- a/src/main/java/me/botsko/prism/commandlibs/Executor.java
+++ b/src/main/java/me/botsko/prism/commandlibs/Executor.java
@@ -37,7 +37,9 @@ public class Executor implements CommandExecutor {
 	
 	/**
 	 * 
-	 * @param prism
+	 * @param plugin
+     * @param mode
+     * @param perm_base
 	 */
 	public Executor( Plugin plugin, String mode, String perm_base ) {
 		this.mode = (mode == null ? "command" : mode);
@@ -113,8 +115,8 @@ public class Executor implements CommandExecutor {
 	
 	/**
 	 * 
-	 * @param name
-	 * @param permission
+	 * @param commandAliases
+	 * @param permissionNodes
 	 * @param handler
 	 * @return
 	 */
@@ -129,8 +131,8 @@ public class Executor implements CommandExecutor {
 	
 	/**
 	 * 
-	 * @param name
-	 * @param permission
+	 * @param commandAliases
+	 * @param permissionNodes
 	 * @return
 	 */
 	protected SubCommand addSub( String[] commandAliases, String[] permissionNodes ) {
@@ -140,9 +142,8 @@ public class Executor implements CommandExecutor {
 	
 	/**
 	 * 
-	 * @param name
-	 * @param permission
-	 * @param handler
+	 * @param commandAliases
+	 * @param permissionNode
 	 * @return
 	 */
 	protected SubCommand addSub( String[] commandAliases, String permissionNode ) {
@@ -152,9 +153,8 @@ public class Executor implements CommandExecutor {
 	
 	/**
 	 * 
-	 * @param name
-	 * @param permission
-	 * @param handler
+	 * @param commandAlias
+	 * @param permissionNodes
 	 * @return
 	 */
 	protected SubCommand addSub( String commandAlias, String[] permissionNodes ) {
@@ -164,9 +164,8 @@ public class Executor implements CommandExecutor {
 	
 	/**
 	 * 
-	 * @param name
-	 * @param permission
-	 * @param handler
+	 * @param commandAlias
+	 * @param permissionNode
 	 * @return
 	 */
 	protected SubCommand addSub( String commandAlias, String permissionNode ) {

--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -330,7 +330,7 @@ public class PreprocessArgs {
 							parameters.setAllowNoRadius(true);
 							
 						} else {
-							respond( sender, Prism.messenger.playerError("Radius is invalid. There's a bunch of choice, so use /prism actions for a assitance.") );
+							respond( sender, Prism.messenger.playerError("Radius is invalid. There's a bunch of choice, so use /prism actions for assistance.") );
 							return null;
 						}
 					}
@@ -477,7 +477,7 @@ public class PreprocessArgs {
 			
 			// Validate any required args are set
 			if(foundArgs.isEmpty()){
-				respond( sender, Prism.messenger.playerError("You're missing valid parameters. Use /prism ? for a assitance.") );
+				respond( sender, Prism.messenger.playerError("You're missing valid parameters. Use /prism ? for assistance.") );
 				return null;
 			}
 			
@@ -558,7 +558,7 @@ public class PreprocessArgs {
 						else if(tfFormat.equals("s")){
 							cal.add(Calendar.SECOND, -1 * tfValue);
 						} else {
-							respond( sender, Prism.messenger.playerError("Invalid timeframe values for "+tfFormat+". Use /prism ? for a help.") );
+							respond( sender, Prism.messenger.playerError("Invalid timeframe values for "+tfFormat+". Use /prism ? for help.") );
 							return null;
 						}
 					}
@@ -569,7 +569,7 @@ public class PreprocessArgs {
 		}
 		
 		if(dateFrom == null){
-			respond( sender, Prism.messenger.playerError("Invalid timeframe values. Use /prism ? for a help.") );
+			respond( sender, Prism.messenger.playerError("Invalid timeframe values. Use /prism ? for help.") );
 		}
 
 		return dateFrom;

--- a/src/main/java/me/botsko/prism/commandlibs/SubCommand.java
+++ b/src/main/java/me/botsko/prism/commandlibs/SubCommand.java
@@ -14,8 +14,8 @@ public final class SubCommand {
 	
 	/**
 	 * 
-	 * @param name
-	 * @param permission
+	 * @param commandAliases
+	 * @param permissionNodes
 	 */
 	public SubCommand( String[] commandAliases, String[] permissionNodes ){
 		this.commandAliases = commandAliases;
@@ -25,8 +25,8 @@ public final class SubCommand {
 	
 	/**
 	 * 
-	 * @param name
-	 * @param permission
+	 * @param commandAliases
+	 * @param permissionNodes
 	 * @param handler
 	 */
 	public SubCommand( String[] commandAliases, String[] permissionNodes, SubHandler handler ){
@@ -121,7 +121,7 @@ public final class SubCommand {
 	
 	/**
 	 * 
-	 * @param node
+	 * @param permissionNodes
 	 */
 	public void setPermNodes( String[] permissionNodes ){
 		this.permissionNodes = permissionNodes;

--- a/src/main/java/me/botsko/prism/commands/ActionsCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ActionsCommand.java
@@ -26,7 +26,7 @@ public class ActionsCommand implements SubHandler {
 	
 	/**
 	 * Display param help
-	 * @param player
+	 * @param sender
 	 */
 	private void help( CommandSender sender ) {
 		

--- a/src/main/java/me/botsko/prism/commands/DrainCommand.java
+++ b/src/main/java/me/botsko/prism/commands/DrainCommand.java
@@ -63,7 +63,7 @@ public class DrainCommand implements SubHandler {
 		if(radius == 0) return;
 		
 		// Build seeking message
-		String msg = "Seeking "+drain_type+" within "+radius+" blocks.";
+		String msg = "Looking for "+drain_type+" within "+radius+" blocks.";
 		if(drain_type.equals("water")){
 			msg += ChatColor.GRAY + " It's just too wet.";
 		}
@@ -95,7 +95,7 @@ public class DrainCommand implements SubHandler {
 			plugin.getServer().getPluginManager().callEvent(event);
 			
 		} else {
-			call.getPlayer().sendMessage(Prism.messenger.playerError("Nothing found to drain with that radius."));
+			call.getPlayer().sendMessage(Prism.messenger.playerError("Nothing found to drain within that radius."));
 		}
 	}
 	

--- a/src/main/java/me/botsko/prism/commands/ExtinguishCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ExtinguishCommand.java
@@ -64,7 +64,7 @@ public class ExtinguishCommand implements SubHandler {
 			plugin.getServer().getPluginManager().callEvent(event);
 			
 		} else {
-			call.getPlayer().sendMessage(Prism.messenger.playerError("No fired found within that radius to extinguish."));
+			call.getPlayer().sendMessage(Prism.messenger.playerError("No fires found within that radius to extinguish."));
 		}
 	}
 }

--- a/src/main/java/me/botsko/prism/commands/FlagsCommand.java
+++ b/src/main/java/me/botsko/prism/commands/FlagsCommand.java
@@ -21,7 +21,7 @@ public class FlagsCommand implements SubHandler {
 	
 	/**
 	 * Display param help
-	 * @param player
+	 * @param sender
 	 */
 	private void help( CommandSender sender ) {
 		

--- a/src/main/java/me/botsko/prism/commands/HelpCommand.java
+++ b/src/main/java/me/botsko/prism/commands/HelpCommand.java
@@ -20,29 +20,31 @@ public class HelpCommand implements SubHandler {
 
 	/**
 	 * Displays help
-	 * @param player
+	 * @param sender
 	 */
 	protected void help( CommandSender sender ){
 		
 		sender.sendMessage( Prism.messenger.playerHeaderMsg( ChatColor.GOLD + "--- Basic Usage ---" ) );
 		
-		sender.sendMessage( Prism.messenger.playerHelp("i", "Toggles the inspector wand."));
-		sender.sendMessage( Prism.messenger.playerHelp("(l|lookup) (params)", "Search the database"));
+		sender.sendMessage( Prism.messenger.playerHelp("i", "Toggle the inspector wand."));
+		sender.sendMessage( Prism.messenger.playerHelp("(l|lookup) (params)", "Search the database."));
+        sender.sendMessage( Prism.messenger.playerHelp("tp (#|id:#)", "Teleport to a lookup result."));
 		sender.sendMessage( Prism.messenger.playerHelp("near", "Find all changes nearby."));
-		sender.sendMessage( Prism.messenger.playerHelp("pg (#|next|prev)", "Skip to a page of last results."));
-		sender.sendMessage( Prism.messenger.playerHelp("params", "Lists parameter help."));
-		sender.sendMessage( Prism.messenger.playerHelp("actions", "Lists actions."));
-		sender.sendMessage( Prism.messenger.playerHelp("flags", "Lists possible applier flags."));
+		sender.sendMessage( Prism.messenger.playerHelp("pg (#|next|prev)", "Navigate lookup results."));
+		sender.sendMessage( Prism.messenger.playerHelp("params", "List parameter help."));
+		sender.sendMessage( Prism.messenger.playerHelp("actions", "List actions."));
+		sender.sendMessage( Prism.messenger.playerHelp("flags", "List possible applier flags."));
 		sender.sendMessage( Prism.messenger.playerHelp("(preview|pv) (rollback|rb) (params)", "Preview a rollback."));
 		sender.sendMessage( Prism.messenger.playerHelp("(preview|pv) (restore|rs) (params)", "Preview a restoration."));
-		sender.sendMessage( Prism.messenger.playerHelp("(preview|pv) apply", "Applies the last preview."));
-		sender.sendMessage( Prism.messenger.playerHelp("(preview|pv) cancel", "Cancels the last preview."));
+		sender.sendMessage( Prism.messenger.playerHelp("(preview|pv) apply", "Apply the last preview."));
+		sender.sendMessage( Prism.messenger.playerHelp("(preview|pv) cancel", "Cancel the last preview."));
 		sender.sendMessage( Prism.messenger.playerHelp("(rollback|rb) (params)", "Rollback changes."));
-		sender.sendMessage( Prism.messenger.playerHelp("(restore|rs) (params)", "Re-applies changes."));
-		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) profile", "Toggles the profile wand."));
-		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) rollback", "Toggles the rollback wand."));
-		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) restore", "Toggles the restore wand."));
-		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) off", "Disables current wand"));
+		sender.sendMessage( Prism.messenger.playerHelp("(restore|rs) (params)", "Re-apply changes."));
+		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) profile", "Toggle the profile wand."));
+		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) rollback", "Toggle the rollback wand."));
+		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) restore", "Toggle the restore wand."));
+		sender.sendMessage( Prism.messenger.playerHelp("(w|wand) off", "Disable current wand."));
+        sender.sendMessage( Prism.messenger.playerHelp("undo", "Undo a drain."));
 		sender.sendMessage( Prism.messenger.playerHelp("ex (r)", "Extinguish fires within a (r)adius."));
 		sender.sendMessage( Prism.messenger.playerHelp("drain (r)", "Drain water/lava within a (r)adius."));
 		sender.sendMessage( Prism.messenger.playerHelp("delete (params)", "Purge records based on (params). No defaults!"));
@@ -50,8 +52,8 @@ public class HelpCommand implements SubHandler {
 		sender.sendMessage( Prism.messenger.playerHelp("setmy wand item (item id)", "Set your personal wand item/block id:subid."));
 		sender.sendMessage( Prism.messenger.playerHelp("resetmy (wand)", "Reset your custom wand settings to server defaults."));
 		sender.sendMessage( Prism.messenger.playerHelp("(rp|report) queue", "Display statistics on current queues."));
-		sender.sendMessage( Prism.messenger.playerHelp("about", "Prism credits."));
-		sender.sendMessage( Prism.messenger.playerHelp("reload", "Reloads config/language files."));
+		sender.sendMessage( Prism.messenger.playerHelp("about", "Show Prism credits."));
+		sender.sendMessage( Prism.messenger.playerHelp("reload", "Reload config/language files."));
 		
 	}
 }

--- a/src/main/java/me/botsko/prism/commands/ParamsCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ParamsCommand.java
@@ -20,14 +20,14 @@ public class ParamsCommand implements SubHandler {
 	
 	/**
 	 * Display param help
-	 * @param player
+	 * @param sender
 	 */
 	private void help( CommandSender sender ) {
 		
 		sender.sendMessage( Prism.messenger.playerHeaderMsg( ChatColor.GOLD + "--- Parameters Help ---" ) );
 		
 		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "r:[radius]" + ChatColor.WHITE + " i.e. 20, or 100. Defaults to default-radius defined in config.") );
-		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "r:global" + ChatColor.WHITE + " Force an everywhere search, for lookups only (unless config'd for rollbacks).") );
+		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "r:global" + ChatColor.WHITE + " Force a worldwide search, for lookups only (unless configured for rollbacks).") );
 		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "r:<player|x,y,z>:[radius]" + ChatColor.WHITE + " Base the radius around another place, like r:viveleroi:20 or r:20,35,10:5 (x,y,z)") );
 		sender.sendMessage( Prism.messenger.playerMsg( ChatColor.LIGHT_PURPLE + "r:we" + ChatColor.WHITE + " Use a WorldEdit selection.") );
 		

--- a/src/main/java/me/botsko/prism/commands/PreviewCommand.java
+++ b/src/main/java/me/botsko/prism/commands/PreviewCommand.java
@@ -90,7 +90,7 @@ public class PreviewCommand implements SubHandler {
 				parameters.setStringFromRawArgs( call.getArgs(), 1 );
 				
 				if(parameters.getActionTypes().containsKey("world-edit")){
-					call.getPlayer().sendMessage( Prism.messenger.playerError("Prism does not yet support previews for world edit rollbacks/restores.") );
+					call.getPlayer().sendMessage( Prism.messenger.playerError("Prism does not support previews for WorldEdit rollbacks/restores yet.") );
 					return;
 				}
 				

--- a/src/main/java/me/botsko/prism/commands/SetmyCommand.java
+++ b/src/main/java/me/botsko/prism/commands/SetmyCommand.java
@@ -139,7 +139,7 @@ public class SetmyCommand implements SubHandler {
 						if( item_name != null ){
 							
 							if( !ItemUtils.isAcceptableWand( item_id, item_subid ) ){
-								call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry but you may not use " + item_name + " for a wand.") );
+								call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but you may not use " + item_name + " for a wand.") );
 								return;
 							}
 							

--- a/src/main/java/me/botsko/prism/commands/UndoCommand.java
+++ b/src/main/java/me/botsko/prism/commands/UndoCommand.java
@@ -50,7 +50,7 @@ public class UndoCommand implements SubHandler {
 			if(TypeUtils.isNumeric(call.getArg(1))){
 				record_id = Integer.parseInt(call.getArg(1));
 				if(record_id <= 0){
-					call.getPlayer().sendMessage( Prism.messenger.playerError("Record id must be greater than zero." ) );
+					call.getPlayer().sendMessage( Prism.messenger.playerError("Record ID must be greater than zero." ) );
 					return;
 				}
 			} else {
@@ -61,7 +61,7 @@ public class UndoCommand implements SubHandler {
 			
 			// Invalid id
 			if(record_id == 0){
-				call.getPlayer().sendMessage( Prism.messenger.playerError("Either you have no last process or an invalid id." ) );
+				call.getPlayer().sendMessage( Prism.messenger.playerError("Either you have no last process or an invalid ID." ) );
 				return;
 			}
 			

--- a/src/main/java/me/botsko/prism/commands/ViewCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ViewCommand.java
@@ -50,7 +50,7 @@ public class ViewCommand implements SubHandler {
 				ChunkUtils.resetPreviewBoundaryBlocks( call.getPlayer(), blocks );
 				
 				// Close
-				call.getSender().sendMessage( Prism.messenger.playerHeaderMsg("Reset your current view") );
+				call.getSender().sendMessage( Prism.messenger.playerHeaderMsg("Reset your current view.") );
 				plugin.playerActiveViews.remove(playerName);
 				
 			} else {
@@ -62,13 +62,13 @@ public class ViewCommand implements SubHandler {
 				ChunkUtils.setPreviewBoundaryBlocks( call.getPlayer(), blocks, Material.GLOWSTONE );
 				plugin.playerActiveViews.put(playerName, blocks);
 				
-				call.getSender().sendMessage( Prism.messenger.playerHeaderMsg("Showing current chunk boundaries") );
+				call.getSender().sendMessage( Prism.messenger.playerHeaderMsg("Showing current chunk boundaries.") );
 				
 			}
 			return;
 		}
 		
-		call.getSender().sendMessage( Prism.messenger.playerError("Invalid view option. See /pr ? for assistance.") );
+		call.getSender().sendMessage( Prism.messenger.playerError("Invalid view option. Use /prism ? for help.") );
 		
 	}
 }

--- a/src/main/java/me/botsko/prism/commands/WhatCommand.java
+++ b/src/main/java/me/botsko/prism/commands/WhatCommand.java
@@ -44,7 +44,7 @@ public class WhatCommand extends Executor {
         		
         		String line1 = ChatColor.WHITE + "Name: " + ChatColor.DARK_AQUA + item.getType().toString().toLowerCase();
         		line1 += ChatColor.WHITE + " Prism Alias: " + ChatColor.DARK_AQUA + prism.getItems().getAlias(item.getTypeId(), item.getDurability() );
-        		line1 += ChatColor.WHITE + " Id: " + ChatColor.DARK_AQUA + item.getTypeId()+":" + item.getDurability();
+        		line1 += ChatColor.WHITE + " ID: " + ChatColor.DARK_AQUA + item.getTypeId()+":" + item.getDurability();
         		
         		call.getPlayer().sendMessage( Prism.messenger.playerMsg( line1 ) );
         		call.getPlayer().sendMessage( Prism.messenger.playerMsg( ChatColor.WHITE + "Full Display Name: " + ChatColor.DARK_AQUA + ItemUtils.getItemFullNiceName( item, prism.getItems() ) ) );

--- a/src/main/java/me/botsko/prism/events/BlockStateChange.java
+++ b/src/main/java/me/botsko/prism/events/BlockStateChange.java
@@ -17,7 +17,8 @@ public class BlockStateChange {
     
     /**
      * 
-     * @param example
+     * @param originalBlock
+     * @param newBlock
      */
     public BlockStateChange( BlockState originalBlock, BlockState newBlock ) {
         this.originalBlock = originalBlock;

--- a/src/main/java/me/botsko/prism/events/PrismBlocksDrainEvent.java
+++ b/src/main/java/me/botsko/prism/events/PrismBlocksDrainEvent.java
@@ -33,7 +33,9 @@ public class PrismBlocksDrainEvent extends Event {
     
     /**
      * 
-     * @param example
+     * @param blockStateChanges
+     * @param onBehalfOf
+     * @param radius
      */
     public PrismBlocksDrainEvent( ArrayList<BlockStateChange> blockStateChanges, Player onBehalfOf, int radius ) {
         this.blockStateChanges = blockStateChanges;

--- a/src/main/java/me/botsko/prism/events/PrismBlocksExtinguishEvent.java
+++ b/src/main/java/me/botsko/prism/events/PrismBlocksExtinguishEvent.java
@@ -33,7 +33,9 @@ public class PrismBlocksExtinguishEvent extends Event {
     
     /**
      * 
-     * @param example
+     * @param blockStateChanges
+     * @param onBehalfOf
+     * @param radius
      */
     public PrismBlocksExtinguishEvent( ArrayList<BlockStateChange> blockStateChanges, Player onBehalfOf, int radius ) {
         this.blockStateChanges = blockStateChanges;

--- a/src/main/java/me/botsko/prism/events/PrismBlocksRollbackEvent.java
+++ b/src/main/java/me/botsko/prism/events/PrismBlocksRollbackEvent.java
@@ -40,8 +40,11 @@ public class PrismBlocksRollbackEvent extends Event {
  
     
     /**
-     * 
-     * @param example
+     *
+     * @param blockStateChanges
+     * @param onBehalfOf
+     * @param parameters
+     * @param result
      */
     public PrismBlocksRollbackEvent( ArrayList<BlockStateChange> blockStateChanges, Player onBehalfOf, QueryParameters parameters, ApplierResult result ) {
         this.blockStateChanges = blockStateChanges;

--- a/src/main/java/me/botsko/prism/events/PrismCustomPlayerActionEvent.java
+++ b/src/main/java/me/botsko/prism/events/PrismCustomPlayerActionEvent.java
@@ -17,7 +17,10 @@ public class PrismCustomPlayerActionEvent extends Event {
 
     /**
      * 
-     * @param example
+     * @param plugin
+     * @param action_type_name
+     * @param player
+     * @param message
      */
     public PrismCustomPlayerActionEvent( Plugin plugin, String action_type_name, Player player, String message ){
     	this.plugin_name = plugin.getName();

--- a/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
@@ -115,7 +115,7 @@ public class PrismBlockEvents implements Listener {
 	
 	/**
 	 * 
-	 * @param player
+	 * @param playername
 	 * @param block
 	 */
 	protected void logBlockRelationshipsForBlock( String playername, Block block ){

--- a/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
@@ -361,11 +361,11 @@ public class PrismInventoryEvents implements Listener {
 	
 	
 	/**
-	 * 
+	 *
+     * @param player
 	 * @param item
+     * @param slot
 	 * @param actionType
-	 * @param containerLoc
-	 * @param event
 	 */
 	protected void recordInvAction( Player player, ItemStack item, int slot, String actionType ){
 		

--- a/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
@@ -83,7 +83,7 @@ public class PrismPlayerEvents implements Listener {
 		if( plugin.getConfig().getBoolean("prism.alerts.illegal-commands.enabled") ){
 			if( illegalCommands.contains( primaryCmd) ){
 				String msg = player.getName() + " attempted an illegal command: " + primaryCmd + ". Originally: " + cmd;
-				player.sendMessage( Prism.messenger.playerError("Sorry, this command has disabled from in-game use.") );
+				player.sendMessage( Prism.messenger.playerError("Sorry, this command is not available in-game.") );
 	        	plugin.alertPlayers( null, msg );
 	        	event.setCancelled(true);
 	        	// Log to console
@@ -477,7 +477,6 @@ public class PrismPlayerEvents implements Listener {
 	 * 
 	 * @param block
 	 * @param inhand
-	 * @param clickedFace
 	 * @param player
 	 */
 	protected void recordMonsterEggUse( Block block, ItemStack inhand, String player ){

--- a/src/main/java/me/botsko/prism/utils/BlockUtils.java
+++ b/src/main/java/me/botsko/prism/utils/BlockUtils.java
@@ -52,7 +52,7 @@ public class BlockUtils extends me.botsko.elixr.BlockUtils {
 	
 	/**
 	 * 
-	 * @param mat
+	 * @param materials
 	 * @param loc
 	 * @param radius
 	 */

--- a/src/main/java/me/botsko/prism/wands/InspectorWand.java
+++ b/src/main/java/me/botsko/prism/wands/InspectorWand.java
@@ -67,7 +67,7 @@ public class InspectorWand extends QueryWandBase implements Wand {
 					params = parameters.clone();
 				} catch (CloneNotSupportedException ex) {
 					params = new QueryParameters();
-					player.sendMessage(Prism.messenger.playerError("Error retreiving parameters. Checking with default parameters."));
+					player.sendMessage(Prism.messenger.playerError("Error retrieving parameters. Checking with default parameters."));
 				}
 				params.setWorld( player.getWorld().getName() );
 				params.setSpecificBlockLocation(loc);

--- a/src/main/java/me/botsko/prism/wands/RestoreWand.java
+++ b/src/main/java/me/botsko/prism/wands/RestoreWand.java
@@ -61,7 +61,7 @@ public class RestoreWand extends QueryWandBase implements Wand {
 			params = parameters.clone();
 		} catch (CloneNotSupportedException ex) {
 			params = new QueryParameters();
-			player.sendMessage(Prism.messenger.playerError("Error retreiving parameters. Checking with default parameters."));
+			player.sendMessage(Prism.messenger.playerError("Error retrieving parameters. Checking with default parameters."));
 		}
 		
 		params.setWorld( player.getWorld().getName() );
@@ -85,7 +85,7 @@ public class RestoreWand extends QueryWandBase implements Wand {
 			Restore rb = new Restore( plugin, player, results.getActionResults(), params, new PrismApplierCallback() );
 			rb.apply();
 		} else {
-			String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().toLowerCase() + " block");
+            String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().replaceAll("_", " ").toLowerCase() + (block.getType().toString().endsWith("block") ? "" : " block"));
 			player.sendMessage( Prism.messenger.playerError( "Nothing to restore for this " + space_name + " found." ) );
 		}
 	}

--- a/src/main/java/me/botsko/prism/wands/RollbackWand.java
+++ b/src/main/java/me/botsko/prism/wands/RollbackWand.java
@@ -89,7 +89,7 @@ public class RollbackWand extends QueryWandBase implements Wand{
 			Rollback rb = new Rollback( plugin, player, results.getActionResults(), params, new PrismApplierCallback() );
 			rb.apply();
 		} else {
-			String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().toLowerCase() + " block");
+            String space_name = (block.getType().equals(Material.AIR) ? "space" : block.getType().toString().replaceAll("_", " ").toLowerCase() + (block.getType().toString().endsWith("block") ? "" : " block"));
 			player.sendMessage( Prism.messenger.playerError( "Nothing to rollback for this " + space_name + " found." ) );
 		}
 	}

--- a/src/main/java/me/botsko/prism/wands/RollbackWand.java
+++ b/src/main/java/me/botsko/prism/wands/RollbackWand.java
@@ -66,7 +66,7 @@ public class RollbackWand extends QueryWandBase implements Wand{
 			params = parameters.clone();
 		} catch (CloneNotSupportedException ex) {
 			params = new QueryParameters();
-			player.sendMessage(Prism.messenger.playerError("Error retreiving parameters. Checking with default parameters."));
+			player.sendMessage(Prism.messenger.playerError("Error retrieving parameters. Checking with default parameters."));
 		}
 		params.setWorld( player.getWorld().getName() );
 		params.setSpecificBlockLocation( block.getLocation());


### PR DESCRIPTION
This commit attempts to fix some spelling and grammar issues for player output throughout the plugin. For example, "No fired found (...)" has been changed to "No fires found (...)".

Any documentation that had nonexistent parameters has been corrected.

PS: Quick note about the changes to `HelpCommand.java`:
These changes make all command descriptions more consistent, i.e.:
`/prism i - Toggle the inspector wand ; /prism (l|lookup) (params) - Search the database` instead of `/prism i - Toggles the inspector wand ; /prism (l|lookup) (params) - Search the database`. The aim is to make the command description seem more like _what can you do with this command?_ as opposed to _what does Prism do when you enter this command?_

Two missing commands (`tp` and `undo`) have been added to the list, and the changes in #35 have also been applied to the rollback and restore wand.
