### PR TITLE
Replace CraftBukkit dependency with Google Gson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 			<version>1.6.2-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>org.bukkit</groupId>
-			<artifactId>craftbukkit</artifactId>
-			<version>1.6.2-R0.1-SNAPSHOT</version>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.2.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q</groupId>

--- a/src/main/java/me/botsko/prism/actions/GenericAction.java
+++ b/src/main/java/me/botsko/prism/actions/GenericAction.java
@@ -3,6 +3,8 @@ package me.botsko.prism.actions;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import me.botsko.elixr.MaterialAliases;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionType;
@@ -11,8 +13,6 @@ import me.botsko.prism.appliers.ChangeResult;
 
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.craftbukkit.libs.com.google.gson.Gson;
-import org.bukkit.craftbukkit.libs.com.google.gson.GsonBuilder;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 


### PR DESCRIPTION
Currently, Prism only depends on CraftBukkit for one feature: Gson serialization.

By replacing the CraftBukkit dependency with the Google Gson dependency, the dependency load on Prism is reduced.
