### PR TITLE
Added InventoryOpenEvent and InventoryCloseEvent.

### DIFF
--- a/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/src/main/java/me/botsko/prism/PrismConfig.java
@@ -144,7 +144,8 @@ public class PrismConfig extends ConfigBase {
 		config.addDefault("prism.tracking.block-use", true);
 		config.addDefault("prism.tracking.bucket-fill", true);
 		config.addDefault("prism.tracking.bonemeal-use", true);
-		config.addDefault("prism.tracking.container-access", true);
+		config.addDefault("prism.tracking.container-open", true);
+		config.addDefault("prism.tracking.container-close", true);
 		config.addDefault("prism.tracking.cake-eat", true);
 		config.addDefault("prism.tracking.craft-item", false);
 		config.addDefault("prism.tracking.creeper-explode", true);

--- a/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
@@ -161,7 +161,8 @@ public class ActionRegistry {
 		registerAction( new ActionType( "bonemeal-use", false, false, false, "UseAction", "used") );
 		registerAction( new ActionType( "bucket-fill", false, false, false, "PlayerAction", "filled") );
 		registerAction( new ActionType( "cake-eat", false, false, false, "UseAction", "ate") );
-		registerAction( new ActionType( "container-access", false, false, false, "BlockAction", "accessed") );
+		registerAction( new ActionType( "container-open", false, false, false, "BlockAction", "opened") );
+		registerAction( new ActionType( "container-close", false, false, false, "BlockAction", "closed") );
 		registerAction( new ActionType( "craft-item", false, false, false, "ItemStackAction", "crafted") );
 		registerAction( new ActionType( "creeper-explode", false, true, true, "BlockAction", "blew up") );
 		registerAction( new ActionType( "crop-trample", false, true, true, "BlockAction", "trampled") );

--- a/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
@@ -8,6 +8,7 @@ import me.botsko.prism.actionlibs.ActionFactory;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.entity.Entity;
@@ -16,8 +17,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.InventoryHolder;
@@ -178,7 +181,58 @@ public class PrismInventoryEvents implements Listener {
 			recordInvAction( player, containerLoc, currentitem, -1, event.isRightClick(), "item-insert");
 		}
 	}
-	
+
+    /**
+     * Handle container access
+     * @param event
+     */
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onInventoryOpen(final InventoryOpenEvent event) {
+
+        Location containerLoc = null;
+
+        // Store some info
+        Player player = (Player) event.getPlayer();
+
+        Block block = null;
+        if (event.getInventory().getHolder() != null && event.getInventory().getHolder() instanceof BlockState)
+        {
+            BlockState state = (BlockState)event.getInventory().getHolder();
+            block = state.getBlock();
+            containerLoc = block.getLocation();
+        }
+        
+        // MCPC+ start - handle container access
+        if( !Prism.getIgnore().event("container-open",player) || block == null ) return;
+            Prism.actionsRecorder.addToQueue( ActionFactory.create("container-open", block, containerLoc, player != null ? player.getName() : "") );
+        // MCPC+ end
+    }
+
+    /**
+     * Handle inventory transfers
+     * @param event
+     */
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onInventoryClose(final InventoryCloseEvent event) {
+
+        Location containerLoc = null;
+
+        // Store some info
+        Player player = (Player) event.getPlayer();
+
+        Block block = null;
+        if (event.getInventory().getHolder() != null && event.getInventory().getHolder() instanceof BlockState)
+        {
+            BlockState state = (BlockState)event.getInventory().getHolder();
+            block = state.getBlock();
+            containerLoc = block.getLocation();
+        }
+        
+        // MCPC+ start - handle container access
+        if( !Prism.getIgnore().event("container-close",player) || block == null ) return;
+            Prism.actionsRecorder.addToQueue( ActionFactory.create("container-close", block, containerLoc, player != null ? player.getName() : "") );
+        // MCPC+ end
+    }
 	
 	/**
 	 *

--- a/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
@@ -401,10 +401,6 @@ public class PrismPlayerEvents implements Listener {
 					}
 					break;
 				default:
-					// MCPC+ start - handle container access
-					if( !Prism.getIgnore().event("container-access",player) ) return;
-						Prism.actionsRecorder.addToQueue( ActionFactory.create("container-access", block, player.getName()) );
-					// MCPC+ end
 					break;
 			}
 			

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -89,7 +89,9 @@ permissions:
         default: false
     prism.ignore.tracking.bonemeal-use:
         default: false
-    prism.ignore.tracking.container-access:
+    prism.ignore.tracking.container-open:
+        default: false
+    prism.ignore.tracking.container-close:
         default: false
     prism.ignore.tracking.cake-eat:
         default: false


### PR DESCRIPTION
- Moved old container-access code to new InventoryOpenEvent listener.
  This fixes container-access showing up during block placement events.
- Renamed container-access to container-open.
- The new action "container-close" has been added to track when players
  close containers. You can turn off this new feature in the config.
