### PR TITLE
Allow users to use the -paste flag to send their data to http://pste.me/with an api key configured. Don't ignore all but the last flag if there are multiple of them. bug 355

### DIFF
--- a/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/src/main/java/me/botsko/prism/PrismConfig.java
@@ -47,6 +47,10 @@ public class PrismConfig extends ConfigBase {
 		config.addDefault("prism.mysql.database", "minecraft");
 		config.addDefault("prism.mysql.port", "3306");
 		
+		// pste.me sharing.
+		config.addDefault("prism.paste.username", "Username on http://pste.me/");
+		config.addDefault("prism.paste.api_key", "");
+		
 		// Wands
 		config.addDefault("prism.wands.default-mode", "hand"); // hand, item, or block
 		config.addDefault("prism.wands.default-item-mode-id", "280:0");

--- a/src/main/java/me/botsko/prism/actionlibs/ActionMessage.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionMessage.java
@@ -47,6 +47,45 @@ public class ActionMessage {
 		this.index = index;
 	}
 	
+	/**
+	 * Here, we don't use formatting or anything,
+	 * we just use a regular message raw.
+	 * 
+	 * This will automatically show extended
+	 * information, as this can be
+	 * passed to a pastebin service.
+	 * 
+	 * @return
+	 */
+	public String getRawMessage(){
+		StringBuilder msg = new StringBuilder();
+		msg.append((a.getType().doesCreateBlock() || a.getType().getName().equals("item-insert") 
+				|| a.getType().getName().equals("sign-change")) ? "+" : "-");
+		msg.append(" #" + a.getId());
+		msg.append(" " + a.getPlayerName());
+		msg.append(" " + a.getType().getName());
+		msg.append(" " + a.getBlockId() + ":" + a.getBlockSubId());
+		if(a.getType().getHandler() != null){
+			if( !a.getNiceName().isEmpty() ) msg.append( " (" + a.getNiceName() + ")");
+		} else {
+			// We should really improve this, but this saves me from having to make
+			// a custom handler.
+			if(a.getType().getName().equals("lava-bucket")){
+				msg.append(" (lava)");
+			} 
+			else if (a.getType().getName().equals("water-bucket")){
+				msg.append(" (water)");
+			}
+		}
+		if( a.getAggregateCount() > 1 ){
+			msg.append(" x" + a.getAggregateCount());
+		}
+		msg.append(" " + a.getDisplayDate());
+		msg.append(" " + a.getDisplayTime().toLowerCase());
+		msg.append(" - " + a.getWorldName() + " @ " + a.getX() + " " + a.getY() + " " + a.getZ());
+		return msg.toString();
+	}
+	
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/commandlibs/Flag.java
+++ b/src/main/java/me/botsko/prism/commandlibs/Flag.java
@@ -10,7 +10,8 @@ public enum Flag {
 	PER_PAGE("-per-page=#", "Set results per-page for current lookup."),
 	NO_GROUP("Disables grouping of related actions."),
 	OVERWRITE("Forces rb/rs to not skip blocks if something unexpected is at location."),
-	SHARE("-share=player1[,player2...]", "Share a lookup result with another player.");
+	SHARE("-share=player1[,player2...]", "Share a lookup result with another player."),
+	PASTE("Share your results with a pastebin service and return the link");
 	
 	private String description;
 	private String usage;

--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -8,6 +8,7 @@ import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
+import me.botsko.prism.parameters.FlagParameter;
 import me.botsko.prism.parameters.PrismParameterHandler;
 
 import org.bukkit.command.CommandSender;
@@ -75,8 +76,11 @@ public class PreprocessArgs {
 						}
 						
 						handlerFound = true;
-						
-						foundArgs.put( entry.getValue().getName().toLowerCase(), m );
+						if(entry.getValue() instanceof FlagParameter){
+							foundArgs.put(entry.getValue().getName().toLowerCase() + "/" + m.group(2).toLowerCase(), m);
+						} else {
+							foundArgs.put( entry.getValue().getName().toLowerCase(), m );
+						}
 						continue;
 
 					} else {
@@ -125,7 +129,7 @@ public class PreprocessArgs {
 			 */
 			for( Entry<String,Matcher> entry : foundArgs.entrySet() ){
 				try {
-					PrismParameterHandler handler = registeredParams.get(entry.getKey());
+					PrismParameterHandler handler = registeredParams.get(entry.getKey().replaceFirst("\\/.*", ""));
 					handler.process( parameters, entry.getValue(), sender );
 				} catch ( IllegalArgumentException e ){
 					if( sender != null ) sender.sendMessage( Prism.messenger.playerError(e.getMessage()) );

--- a/src/main/java/me/botsko/prism/commands/LookupCommand.java
+++ b/src/main/java/me/botsko/prism/commands/LookupCommand.java
@@ -2,6 +2,7 @@ package me.botsko.prism.commands;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionMessage;
 import me.botsko.prism.actionlibs.ActionsQuery;
@@ -13,6 +14,8 @@ import me.botsko.prism.commandlibs.CallInfo;
 import me.botsko.prism.commandlibs.Flag;
 import me.botsko.prism.commandlibs.PreprocessArgs;
 import me.botsko.prism.commandlibs.SubHandler;
+import me.botsko.prism.utils.MiscUtils;
+
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 
@@ -102,6 +105,13 @@ public class LookupCommand implements SubHandler {
 							}
 						} else {
 							player.sendMessage( Prism.messenger.playerError( "Pagination can't find anything. Do you have the right page number?" ) );
+						}
+						if(parameters.hasFlag(Flag.PASTE)){
+							String paste = "";
+							for(Handler a : results.getActionResults()){
+								paste += new ActionMessage(a).getRawMessage() + "\r\n";
+							}
+							player.sendMessage( Prism.messenger.playerMsg(MiscUtils.paste_results(plugin, paste)) );
 						}
 					} else {
 						if(!defaultsReminder.isEmpty()){

--- a/src/main/java/me/botsko/prism/utils/MiscUtils.java
+++ b/src/main/java/me/botsko/prism/utils/MiscUtils.java
@@ -1,7 +1,21 @@
 package me.botsko.prism.utils;
 
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+import javax.xml.bind.DatatypeConverter;
+
+import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.craftbukkit.libs.com.google.gson.Gson;
 import org.bukkit.entity.Player;
+import org.json.simple.JSONObject;
 
 import me.botsko.prism.Prism;
 import me.botsko.prism.appliers.PrismProcessType;
@@ -55,8 +69,51 @@ public class MiscUtils {
 			// Otherwise non-player
 			return desiredRadius;
 		} else {
-			// Otherwuse, the radius is valid and is not exceeding max
+			// Otherwise, the radius is valid and is not exceeding max
 			return desiredRadius;
 		}
+	}
+	
+	public static String paste_results(Prism prism, String results){
+		
+		if(prism.getConfig().get("prism.paste.api_key").equals("")){
+			return ChatColor.LIGHT_PURPLE + "Prism // " + ChatColor.RED
+					+ "Sending information to a pastebin is not configured yet.";
+		}
+		try {
+			String params = "paste=" + URLEncoder.encode(results, "UTF-8");
+			URL url = new URL("http://pste.me/api/v1/paste/"); // http://pste.me/md/api/
+			HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+			connection.setRequestMethod("POST");
+			connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+			connection.setRequestProperty("Content-Length", Integer.toString(params.getBytes().length));
+			connection.setRequestProperty("Content-Language", "en-US");
+			connection.setRequestProperty("Authorization", "Basic " + 
+						DatatypeConverter.printBase64Binary((prism.getConfig().get("prism.paste.username") + ":" 
+						+ prism.getConfig().get("prism.paste.api_key")).getBytes())); // prism.paste. "username"/"api_key"
+			connection.setUseCaches(false);
+			connection.setDoInput(true);
+			connection.setDoOutput(true);
+			DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
+			wr.writeBytes(params);
+			wr.flush();
+			wr.close();
+			InputStream is = connection.getInputStream();
+			BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+			String json = rd.readLine();  // one line
+			Gson gson = new Gson();
+			PasteResponse response = gson.fromJson(json, PasteResponse.class);
+			return ChatColor.LIGHT_PURPLE + "Prism // " + ChatColor.GREEN
+					+ "Successfully pasted results: http://pste.me/" + response.slug + "/";
+		} catch (IOException up) {
+			Prism.debug(up.toString());
+			return ChatColor.LIGHT_PURPLE + "Prism // " + ChatColor.RED 
+					+ "Unable to paste results to pste.me (" + ChatColor.YELLOW 
+					+ up.getMessage() + ChatColor.RED + ").";
+		}
+	}
+	
+	public static class PasteResponse{
+		public String slug = "";
 	}
 }


### PR DESCRIPTION
Flags were being ignored because they were being stored in a `Map` of some sort as {"Flags": aMatch, "Flags": anotherMatch}, so the last ones were overriding the first one.

Now they're stored as "Flags/drain" "Flags/share" and such.

`-paste` sends the data to pste.me with the api-key and username in the config file, and it should work with the -no-group flag.
