### PR TITLE
Various cleanups, bug fixes and a relatively rework of PrismParameterHandler

### DIFF
--- a/src/main/java/me/botsko/prism/ConfigBase.java
+++ b/src/main/java/me/botsko/prism/ConfigBase.java
@@ -15,7 +15,7 @@ public class ConfigBase {
 	/**
 	 * 
 	 */
-	protected Plugin plugin;
+	protected final Plugin plugin;
 	
 	/**
 	 * 
@@ -53,8 +53,7 @@ public class ConfigBase {
 		}
 		
 		// Read the base config
-		FileConfiguration config = loadConfig( "languages/", lang_file );
-		return config;
+		return loadConfig( "languages/", lang_file );
 		
 	}
 	
@@ -64,8 +63,7 @@ public class ConfigBase {
 	 * @return
 	 */
 	protected File getDirectory(){
-		File dir = new File(plugin.getDataFolder()+"");
-		return dir;
+		return new File(plugin.getDataFolder()+"");
 	}
 	
 	
@@ -74,8 +72,7 @@ public class ConfigBase {
 	 * @return
 	 */
 	protected File getFilename( String filename ){
-		File file = new File(getDirectory(), filename + ".yml");
-		return file;
+		return new File(getDirectory(), filename + ".yml");
 	}
 	
 	
@@ -124,7 +121,7 @@ public class ConfigBase {
 			saveConfig( filename, config );
 			bw.flush();
 			bw.close();
-		} catch (IOException e){
+		} catch (IOException ignored){
 
         }
 	}

--- a/src/main/java/me/botsko/prism/Language.java
+++ b/src/main/java/me/botsko/prism/Language.java
@@ -10,7 +10,7 @@ public class Language {
 	/**
 	 * 
 	 */
-	protected FileConfiguration lang;
+	protected final FileConfiguration lang;
 	
 	
 	/**
@@ -65,7 +65,6 @@ public class Language {
 	 * @return
 	 */
 	protected String colorize(String text){
-        String colorized = text.replaceAll("(&([a-f0-9A-F]))", "\u00A7$2");
-        return colorized;
+		return text.replaceAll("(&([a-f0-9A-F]))", "\u00A7$2");
     }
 }

--- a/src/main/java/me/botsko/prism/Messenger.java
+++ b/src/main/java/me/botsko/prism/Messenger.java
@@ -7,7 +7,7 @@ public class Messenger {
 	/**
 	 * 
 	 */
-	protected String plugin_name;
+	protected final String plugin_name;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -294,9 +294,6 @@ public class Prism extends JavaPlugin {
 
 			// Delete old data based on config
 			launchScheduledPurgeManager();
-			
-			// Keep watch on db connections, other sanity
-			launchInternalAffairs();
 
 		}
 	}
@@ -1036,15 +1033,6 @@ public class Prism extends JavaPlugin {
 		// scheduledPurgeExecutor = 
 		schedulePool.scheduleAtFixedRate( purgeManager, 0, 12, TimeUnit.HOURS);
 		// scheduledPurgeExecutor.cancel();
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void launchInternalAffairs(){
-		InternalAffairs recordingMonitor = new InternalAffairs(this);
-		recordingMonitorTask.scheduleAtFixedRate( recordingMonitor, 0, 5, TimeUnit.MINUTES);
 	}
 
 	

--- a/src/main/java/me/botsko/prism/Updater.java
+++ b/src/main/java/me/botsko/prism/Updater.java
@@ -13,7 +13,7 @@ public class Updater {
 	/**
 	 * 
 	 */
-	protected Prism plugin;
+	protected final Prism plugin;
 
 	
 	/**

--- a/src/main/java/me/botsko/prism/actionlibs/ActionFactory.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionFactory.java
@@ -122,6 +122,7 @@ public class ActionFactory {
 		a.setActionType(action_type);
 		a.setLoc(from);
 		a.setToLocation(to);
+		a.setCause(cause);
 		return a;
 	}
 	

--- a/src/main/java/me/botsko/prism/actionlibs/ActionMessage.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionMessage.java
@@ -9,7 +9,7 @@ public class ActionMessage {
 	/**
 	 * 
 	 */
-	protected Handler a;
+	protected final Handler a;
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
@@ -16,7 +16,7 @@ public class ActionRegistry {
 	/**
 	 * 
 	 */
-	private TreeMap<String,ActionType> registeredActions = new TreeMap<String,ActionType>();
+	private final TreeMap<String,ActionType> registeredActions = new TreeMap<String,ActionType>();
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/actionlibs/ActionType.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionType.java
@@ -5,12 +5,12 @@ public class ActionType {
 	/**
 	 * Define associated values
 	 */
-	private boolean doesCreateBlock;
-	private boolean canRollback;
-	private boolean canRestore;
-	private String handler;
-	private String niceDescription;
-	private String name;
+	private final boolean doesCreateBlock;
+	private final boolean canRollback;
+	private final boolean canRestore;
+	private final String handler;
+	private final String niceDescription;
+	private final String name;
 	
 	
 	/**
@@ -107,7 +107,7 @@ public class ActionType {
 	 * @return
 	 */
 	public String getFamilyName(){
-		String[] _tmp = this.name.toLowerCase().split("-(?!.*-.*)");;
+		String[] _tmp = this.name.toLowerCase().split("-(?!.*-.*)");
 		if(_tmp.length == 2){
 			return _tmp[0];
 		}
@@ -120,7 +120,7 @@ public class ActionType {
 	 * @return
 	 */
 	public String getShortName(){
-		String[] _tmp = this.name.toLowerCase().split("-(?!.*-.*)");;
+		String[] _tmp = this.name.toLowerCase().split("-(?!.*-.*)");
 		if(_tmp.length == 2){
 			return _tmp[1];
 		}

--- a/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
@@ -26,12 +26,12 @@ public class ActionsQuery {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	/**
 	 * 
 	 */
-	private SelectQueryBuilder qb;
+	private final SelectQueryBuilder qb;
 	
 	/**
 	 * 
@@ -187,22 +187,20 @@ public class ActionsQuery {
 		    	        	Prism.log("Ignoring data from record #" + rs.getInt(1) + " because it caused an error:" );
 	    	        	}
 	    	        	Prism.log( e.getMessage() );
-	    	        	continue;
-	    	        } catch (Exception e) {
+                    } catch (Exception e) {
 	    	        	if( !rs.isClosed() ){
 		    	        	Prism.log("Ignoring data from record #" + rs.getInt(1) + " because it caused an error:" );
 	    	        	}
 	    	        	Prism.log( e.getMessage() );
-	    	        	continue;
-	    	        }
+                    }
 	    		}
 	            
 	        } catch (SQLException e) {
 	        	plugin.handleDatabaseException( e );
 	        } finally {
-	        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-	        	if(s != null) try { s.close(); } catch (SQLException e) {}
-	        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+	        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+	        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+	        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
 	        }
 		}
 		
@@ -266,9 +264,9 @@ public class ActionsQuery {
         } catch (SQLException e) {
         	plugin.handleDatabaseException( e );
         } finally {
-        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 		return id;
 	}
@@ -320,9 +318,9 @@ public class ActionsQuery {
         } catch (SQLException e) {
         	plugin.handleDatabaseException( e );
         } finally {
-        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 		return process;
 	}
@@ -333,7 +331,7 @@ public class ActionsQuery {
 	 * @return
 	 */
 	public int delete( QueryParameters parameters ){
-		int total_rows_affected = 0, cycle_rows_affected = 0;
+		int total_rows_affected = 0, cycle_rows_affected;
 		Connection conn = null;
 		Statement s = null;
 		try {
@@ -351,8 +349,8 @@ public class ActionsQuery {
 		} catch (SQLException e) {
 			plugin.handleDatabaseException( e );
 		} finally {
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 		return total_rows_affected;
 	}

--- a/src/main/java/me/botsko/prism/actionlibs/HandlerFactory.java
+++ b/src/main/java/me/botsko/prism/actionlibs/HandlerFactory.java
@@ -26,7 +26,6 @@ public class HandlerFactory<H> {
 	 * @throws IllegalAccessException
 	 */
 	public Handler create() throws InstantiationException, IllegalAccessException {
-		Handler handler = handlerClass.newInstance();
-        return handler;
+		return handlerClass.newInstance();
     }
 }

--- a/src/main/java/me/botsko/prism/actionlibs/HandlerRegistry.java
+++ b/src/main/java/me/botsko/prism/actionlibs/HandlerRegistry.java
@@ -30,7 +30,7 @@ public class HandlerRegistry<H> {
 	/**
 	 * 
 	 */
-	private HashMap<String,Class<? extends Handler>> registeredHandlers = new HashMap<String,Class<? extends Handler>>();
+	private final HashMap<String,Class<? extends Handler>> registeredHandlers = new HashMap<String,Class<? extends Handler>>();
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/actionlibs/Ignore.java
+++ b/src/main/java/me/botsko/prism/actionlibs/Ignore.java
@@ -15,7 +15,7 @@ public class Ignore {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	/**
 	 * 
@@ -77,13 +77,9 @@ public class Ignore {
 	 * @return
 	 */
 	public boolean event( String actionTypeName, World world, String player ){
-		
-		if( !event( actionTypeName, world ) ){
-			return false;
-		}
 
-		return event( player );
-		
+		return event(actionTypeName, world) && event(player);
+
 	}
 	
 	
@@ -147,14 +143,10 @@ public class Ignore {
 	 * @return
 	 */
 	public boolean event( String actionTypeName, Block block ){
-		
-		if( !event( actionTypeName, block.getWorld() ) ){
-			return false;
-		}
-		
-		return true;
-		
-	}
+
+        return event(actionTypeName, block.getWorld());
+
+    }
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
@@ -1,17 +1,15 @@
 package me.botsko.prism.actionlibs;
 
+import me.botsko.prism.appliers.PrismProcessType;
+import me.botsko.prism.commandlibs.Flag;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.util.Vector;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.regex.Matcher;
-
-import me.botsko.prism.appliers.PrismProcessType;
-import me.botsko.prism.commandlibs.Flag;
-
-import org.bukkit.Location;
-import org.bukkit.command.CommandSender;
-import org.bukkit.util.Vector;
 
 /**
  * Query Parameters allows you to add values with which Prism
@@ -27,7 +25,7 @@ public class QueryParameters implements Cloneable {
 	 */
 	protected Set<String> foundArgs = new HashSet<String>();
 	protected PrismProcessType processType = PrismProcessType.LOOKUP;
-	protected ArrayList<String> defaultsUsed = new ArrayList<String>();
+	protected final ArrayList<String> defaultsUsed = new ArrayList<String>();
 	protected String original_command;
 	
 	/**
@@ -42,7 +40,7 @@ public class QueryParameters implements Cloneable {
 	protected int parent_id = 0;
 	protected Location player_location;
 	protected int radius;
-	protected ArrayList<Location> specific_block_locations = new ArrayList<Location>();
+	protected final ArrayList<Location> specific_block_locations = new ArrayList<Location>();
 	protected Long since_time;
 	protected Long before_time;
 	protected String world;
@@ -53,11 +51,11 @@ public class QueryParameters implements Cloneable {
 	 * Params that allow multiple values
 	 */
 	protected HashMap<String,MatchRule> actionTypeRules = new HashMap<String,MatchRule>();
-	protected HashMap<Integer,Byte> block_filters = new HashMap<Integer,Byte>();
-	protected HashMap<String,MatchRule> entity_filters = new HashMap<String,MatchRule>();
-	protected HashMap<String,MatchRule> player_names = new HashMap<String,MatchRule>();
-	protected ArrayList<Flag> flags = new ArrayList<Flag>();
-	protected ArrayList<CommandSender> shared_players = new ArrayList<CommandSender>();
+	protected final HashMap<Integer,Byte> block_filters = new HashMap<Integer,Byte>();
+	protected final HashMap<String,MatchRule> entity_filters = new HashMap<String,MatchRule>();
+	protected final HashMap<String,MatchRule> player_names = new HashMap<String,MatchRule>();
+	protected final ArrayList<Flag> flags = new ArrayList<Flag>();
+	protected final ArrayList<CommandSender> shared_players = new ArrayList<CommandSender>();
 	
 	/**
 	 * Pagination

--- a/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryParameters.java
@@ -2,6 +2,8 @@ package me.botsko.prism.actionlibs;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Matcher;
 
 import me.botsko.prism.appliers.PrismProcessType;
@@ -23,7 +25,7 @@ public class QueryParameters implements Cloneable {
 	/**
 	 * Internal use
 	 */
-	protected HashMap<String,Matcher> foundArgs = new HashMap<String,Matcher>();
+	protected Set<String> foundArgs = new HashSet<String>();
 	protected PrismProcessType processType = PrismProcessType.LOOKUP;
 	protected ArrayList<String> defaultsUsed = new ArrayList<String>();
 	protected String original_command;
@@ -451,7 +453,7 @@ public class QueryParameters implements Cloneable {
 	/**
 	 * @return the foundArgs
 	 */
-	public HashMap<String, Matcher> getFoundArgs() {
+	public Set<String> getFoundArgs() {
 		return foundArgs;
 	}
 
@@ -459,7 +461,7 @@ public class QueryParameters implements Cloneable {
 	/**
 	 * @param foundArgs the foundArgs to set
 	 */
-	public void setFoundArgs(HashMap<String, Matcher> foundArgs) {
+	public void setFoundArgs(Set<String> foundArgs) {
 		this.foundArgs = foundArgs;
 	}
 

--- a/src/main/java/me/botsko/prism/actionlibs/QueryResult.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueryResult.java
@@ -15,7 +15,7 @@ public class QueryResult {
 	/**
 	 * 
 	 */
-	protected QueryParameters parameters;
+	protected final QueryParameters parameters;
 	
 	/**
 	 * 
@@ -25,7 +25,7 @@ public class QueryResult {
 	/**
 	 * 
 	 */
-	protected int total_results;
+	protected final int total_results;
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/actionlibs/QueueDrain.java
+++ b/src/main/java/me/botsko/prism/actionlibs/QueueDrain.java
@@ -7,7 +7,7 @@ public class QueueDrain {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/actionlibs/RecordingTask.java
+++ b/src/main/java/me/botsko/prism/actionlibs/RecordingTask.java
@@ -15,7 +15,7 @@ public class RecordingTask implements Runnable {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**
@@ -103,9 +103,9 @@ public class RecordingTask implements Runnable {
         } catch (SQLException e) {
 //        	plugin.handleDatabaseException( e );
         } finally {
-        	if(generatedKeys != null) try { generatedKeys.close(); } catch (SQLException e) {}
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(generatedKeys != null) try { generatedKeys.close(); } catch (SQLException ignored) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 		return id;
 	}
@@ -117,14 +117,12 @@ public class RecordingTask implements Runnable {
 	 * @return
 	 */
 	protected static int getPlayerPrimaryKey( String playerName ){
-		int player_id = 0;
     	if( Prism.prismPlayers.containsKey(playerName) ){
-    		player_id = Prism.prismPlayers.get(playerName);
+    		return Prism.prismPlayers.get(playerName);
     	} else {
     		Prism.cachePlayerPrimaryKey(playerName);
-    		player_id = Prism.prismPlayers.get(playerName);
+    		return Prism.prismPlayers.get(playerName);
     	}
-    	return player_id;
 	}
 	
 	
@@ -172,7 +170,7 @@ public class RecordingTask implements Runnable {
 		        int i = 0;
 		        while (!RecordingQueue.getQueue().isEmpty()){
 		        	
-		        	if( conn == null || conn.isClosed() ){
+		        	if(conn.isClosed()){
 		        		Prism.log("Prism database error. We have to bail in the middle of building primary bulk insert query.");
 		        		break;
 		        	}
@@ -203,7 +201,7 @@ public class RecordingTask implements Runnable {
 		        		continue;
 		        	}
 		        	
-		        	if( a == null || a.isCanceled() ) continue;
+		        	if(a.isCanceled()) continue;
 		        	
 		        	actionsRecorded++;
 		        	
@@ -232,7 +230,7 @@ public class RecordingTask implements Runnable {
 		        
 		        s.executeBatch();
 		        
-		        if( conn == null || conn.isClosed() ){
+		        if(conn.isClosed()){
 	        		Prism.log("Prism database error. We have to bail in the middle of building primary bulk insert query.");
 	        	} else {
 			        conn.commit();
@@ -250,8 +248,8 @@ public class RecordingTask implements Runnable {
 	    	e.printStackTrace();
 	    	plugin.handleDatabaseException( e );
         } finally {
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 	}
 	
@@ -266,9 +264,7 @@ public class RecordingTask implements Runnable {
 		if( extraDataQueue.isEmpty() ) return;
 
 		PreparedStatement s = null;
-		Connection conn = null;
-	    
-		conn = Prism.dbc();
+		Connection conn = Prism.dbc();
 		
 		if( conn == null || conn.isClosed() ){
     		Prism.log("Prism database error. Skipping extra data queue insertion.");
@@ -281,7 +277,7 @@ public class RecordingTask implements Runnable {
 	        int i = 0;
 			while(keys.next()){
 				
-				if( conn == null || conn.isClosed() ){
+				if(conn.isClosed()){
 	        		Prism.log("Prism database error. We have to bail in the middle of building bulk insert extra data query.");
 	        		break;
 	        	}
@@ -305,7 +301,7 @@ public class RecordingTask implements Runnable {
 			}
 			s.executeBatch();
 			
-			if( conn == null || conn.isClosed() ){
+			if(conn.isClosed()){
         		Prism.log("Prism database error. We have to bail in the middle of building extra data bulk insert query.");
         	} else {
 		        conn.commit();
@@ -315,8 +311,8 @@ public class RecordingTask implements Runnable {
 	    	e.printStackTrace();
 	    	plugin.handleDatabaseException( e );
         } finally {
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+			try { conn.close(); } catch (SQLException ignored) {}
         }
 	}
 

--- a/src/main/java/me/botsko/prism/actions/BlockAction.java
+++ b/src/main/java/me/botsko/prism/actions/BlockAction.java
@@ -48,7 +48,7 @@ public class BlockAction extends GenericAction {
 			}
 		
 			// spawner
-			if( block != null && block.getTypeId() == 52 ){
+			if(block.getTypeId() == 52){
 				SpawnerActionData spawnerActionData = new SpawnerActionData();
 				CreatureSpawner s = (CreatureSpawner)block.getState();
 				spawnerActionData.entity_type = s.getSpawnedType().name().toLowerCase();
@@ -57,7 +57,7 @@ public class BlockAction extends GenericAction {
 			}
 			
 			// skulls
-			else if( block != null && (block.getTypeId() == 144 || block.getTypeId() == 397) ){
+			else if((block.getTypeId() == 144 || block.getTypeId() == 397)){
 				SkullActionData skullActionData = new SkullActionData();
 				Skull s = (Skull)block.getState();
 				skullActionData.rotation = s.getRotation().name().toLowerCase();
@@ -67,7 +67,7 @@ public class BlockAction extends GenericAction {
 			}
 			
 			// signs
-			else if( block != null && (block.getTypeId() == 63 || block.getTypeId() == 68) ){
+			else if((block.getTypeId() == 63 || block.getTypeId() == 68)){
 				SignActionData signActionData = new SignActionData();
 				Sign s = (Sign) block.getState();
 				signActionData.lines = s.getLines();
@@ -75,7 +75,7 @@ public class BlockAction extends GenericAction {
 			}
 			
 			// command block
-			else if( block != null && (block.getTypeId() == 137) ){
+			else if((block.getTypeId() == 137)){
 				CommandBlock cmdblock = (CommandBlock) block.getState();
 				data = cmdblock.getCommand();
 			}
@@ -314,7 +314,7 @@ public class BlockAction extends GenericAction {
 	protected ChangeResult placeBlock( Player player, QueryParameters parameters, boolean is_preview, Block block, boolean is_deferred ){
 
 		Material m = Material.getMaterial(getBlockId());
-		BlockStateChange stateChange = null;
+		BlockStateChange stateChange;
 
 		// Ensure block action is allowed to place a block here.
 		// (essentially liquid/air).
@@ -355,7 +355,7 @@ public class BlockAction extends GenericAction {
 				Block obsidian = BlockUtils.getFirstBlockOfMaterialBelow(Material.OBSIDIAN, block.getLocation());
 				if(obsidian != null){
 					Block above = obsidian.getRelative(BlockFace.UP);
-					if(!above.equals(Material.PORTAL)){
+					if(!(above.getType() == Material.PORTAL)){
 						above.setType(Material.FIRE);
 						return new ChangeResult( ChangeResultType.APPLIED, null );
 					}
@@ -503,7 +503,7 @@ public class BlockAction extends GenericAction {
 	 */
 	protected ChangeResult removeBlock( Player player, QueryParameters parameters, boolean is_preview, Block block ){
 		
-		BlockStateChange stateChange = null;
+		BlockStateChange stateChange;
 		
 		if(!block.getType().equals(Material.AIR)){
 			

--- a/src/main/java/me/botsko/prism/actions/EntityAction.java
+++ b/src/main/java/me/botsko/prism/actions/EntityAction.java
@@ -107,10 +107,10 @@ public class EntityAction extends GenericAction {
 	            // Owner
 	            if(wolf.isTamed()){
 	                if(wolf.getOwner() instanceof Player){
-	                	this.actionData.taming_owner = ((Player)wolf.getOwner()).getName();
+	                	this.actionData.taming_owner = wolf.getOwner().getName();
 	                }
 	                if(wolf.getOwner() instanceof OfflinePlayer){
-	                	this.actionData.taming_owner = ((OfflinePlayer)wolf.getOwner()).getName();
+	                	this.actionData.taming_owner = wolf.getOwner().getName();
 	                }
 	            }
 	            
@@ -147,10 +147,10 @@ public class EntityAction extends GenericAction {
 				// Owner
 	            if(h.isTamed()){
 	                if(h.getOwner() instanceof Player){
-	                	this.actionData.taming_owner = ((Player)h.getOwner()).getName();
+	                	this.actionData.taming_owner = h.getOwner().getName();
 	                }
 	                if(h.getOwner() instanceof OfflinePlayer){
-	                	this.actionData.taming_owner = ((OfflinePlayer)h.getOwner()).getName();
+	                	this.actionData.taming_owner = h.getOwner().getName();
 	                }
 	            }
 			}
@@ -263,9 +263,9 @@ public class EntityAction extends GenericAction {
 		if(actionData.color != null && !actionData.color.isEmpty()){
 			name += actionData.color + " ";
 		}
-		if(actionData.isAdult && !actionData.isAdult){
-			name += "baby ";
-		}
+//		if(actionData.isAdult){
+//			name += "baby ";
+//		}
 		if(this.actionData.profession != null){
 			name += this.actionData.profession + " ";
 		}

--- a/src/main/java/me/botsko/prism/actions/GenericAction.java
+++ b/src/main/java/me/botsko/prism/actions/GenericAction.java
@@ -32,7 +32,7 @@ public class GenericAction implements Handler {
 	/**
 	 * 
 	 */
-	protected Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+	protected final Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/actions/HangingItemAction.java
+++ b/src/main/java/me/botsko/prism/actions/HangingItemAction.java
@@ -89,12 +89,7 @@ public class HangingItemAction extends GenericAction {
 	 * @return
 	 */
 	public String getNiceName(){
-		String name = "hangingitem";
-		name = data.toLowerCase();
-		if(this.actionData.type != null){
-			name = this.actionData.type;
-		}
-		return name;
+		return this.actionData.type != null ? this.actionData.type : data.toLowerCase();
 	}
 	
 	

--- a/src/main/java/me/botsko/prism/actions/ItemStackAction.java
+++ b/src/main/java/me/botsko/prism/actions/ItemStackAction.java
@@ -129,12 +129,12 @@ public class ItemStackAction extends GenericAction {
 	        BookMeta bookMeta = (BookMeta) meta;
 			actionData.by = bookMeta.getAuthor();
 			actionData.title = bookMeta.getTitle();
-			actionData.content = (String[]) bookMeta.getPages().toArray(new String[0]);
+			actionData.content = bookMeta.getPages().toArray(new String[0]);
 		}
 		
 		// Lore
 		if( meta != null && meta.getLore() != null ){
-			actionData.lore = (String[]) meta.getLore().toArray(new String[0]);
+			actionData.lore = meta.getLore().toArray(new String[0]);
 		}
 		
 		// Enchantments

--- a/src/main/java/me/botsko/prism/appliers/Preview.java
+++ b/src/main/java/me/botsko/prism/appliers/Preview.java
@@ -28,7 +28,7 @@ public class Preview implements Previewable {
 	/**
 	 * 
 	 */
-	protected Prism plugin;
+	protected final Prism plugin;
 	
 	/**
 	 * 
@@ -58,12 +58,12 @@ public class Preview implements Previewable {
 	/**
 	 * 
 	 */
-	protected HashMap<Entity,Integer> entities_moved = new HashMap<Entity,Integer>();
+	protected final HashMap<Entity,Integer> entities_moved = new HashMap<Entity,Integer>();
 	
 	/**
 	 * 
 	 */
-	protected ArrayList<BlockStateChange> blockStateChanges = new ArrayList<BlockStateChange>();
+	protected final ArrayList<BlockStateChange> blockStateChanges = new ArrayList<BlockStateChange>();
 	
 	/**
 	 * 
@@ -426,7 +426,7 @@ public class Preview implements Previewable {
 	protected void moveEntitiesToSafety(){
 		if( parameters.getWorld() != null && player != null ){
 			List<Entity> entities = player.getNearbyEntities(parameters.getRadius(), parameters.getRadius(), parameters.getRadius());
-			entities.add((Entity)player);
+			entities.add(player);
 			for(Entity entity : entities){
 				if(entity instanceof LivingEntity){
 					int add = 0;

--- a/src/main/java/me/botsko/prism/appliers/Undo.java
+++ b/src/main/java/me/botsko/prism/appliers/Undo.java
@@ -27,6 +27,5 @@ public class Undo extends Preview {
 	 */
 	public void preview(){
 		player.sendMessage( Prism.messenger.playerError("You can't preview an undo.") );
-		return;
 	}
 }

--- a/src/main/java/me/botsko/prism/bridge/PrismBlockEditSession.java
+++ b/src/main/java/me/botsko/prism/bridge/PrismBlockEditSession.java
@@ -20,7 +20,7 @@ public class PrismBlockEditSession extends EditSession {
 	/**
 	 * 
 	 */
-	private LocalPlayer player;
+	private final LocalPlayer player;
 
 	
 	/**

--- a/src/main/java/me/botsko/prism/bridge/PrismBlockEditSessionFactory.java
+++ b/src/main/java/me/botsko/prism/bridge/PrismBlockEditSessionFactory.java
@@ -36,7 +36,7 @@ public class PrismBlockEditSessionFactory extends EditSessionFactory {
 			// Check to see if the world edit version is compatible
 			Class.forName("com.sk89q.worldedit.EditSessionFactory").getDeclaredMethod("getEditSession", LocalWorld.class, int.class, BlockBag.class, LocalPlayer.class);
 			WorldEdit.getInstance().setEditSessionFactory(new PrismBlockEditSessionFactory());
-		} catch (Throwable t) {
+		} catch (Throwable ignored) {
 		
 		}
 	}

--- a/src/main/java/me/botsko/prism/bridge/WorldEditBridge.java
+++ b/src/main/java/me/botsko/prism/bridge/WorldEditBridge.java
@@ -26,7 +26,7 @@ public class WorldEditBridge {
 	 */
 	public static boolean getSelectedArea(Prism plugin, Player player, QueryParameters parameters ){
 		// Get selected area
-		Region region = null;
+		Region region;
 		try {
 			LocalPlayer lp = new BukkitPlayer(Prism.plugin_worldEdit, Prism.plugin_worldEdit.getWorldEdit().getServer(), player);
 			LocalWorld lw = lp.getWorld();

--- a/src/main/java/me/botsko/prism/commandlibs/CallInfo.java
+++ b/src/main/java/me/botsko/prism/commandlibs/CallInfo.java
@@ -8,17 +8,17 @@ public class CallInfo {
 	/**
 	 * 
 	 */
-	private CommandSender sender;
+	private final CommandSender sender;
 	
 	/**
 	 * 
 	 */
-	private Player player;
+	private final Player player;
 	
 	/**
 	 * 
 	 */
-	private String[] args;
+	private final String[] args;
 
 	
 	/**

--- a/src/main/java/me/botsko/prism/commandlibs/Executor.java
+++ b/src/main/java/me/botsko/prism/commandlibs/Executor.java
@@ -13,7 +13,7 @@ public class Executor implements CommandExecutor {
 	/**
 	 * 
 	 */
-	public Plugin plugin;
+	public final Plugin plugin;
 	
 	/**
 	 * Setting the executor to command mode
@@ -32,7 +32,7 @@ public class Executor implements CommandExecutor {
 	/**
 	 * 
 	 */
-	public java.util.Map<String, SubCommand> subcommands = new LinkedHashMap<String, SubCommand>();
+	public final java.util.Map<String, SubCommand> subcommands = new LinkedHashMap<String, SubCommand>();
 
 	
 	/**
@@ -60,7 +60,7 @@ public class Executor implements CommandExecutor {
 
 
 		// Find command
-		String subcommandName = defaultSubcommand;
+		String subcommandName;
 		if(mode.equals("subcommand") && args.length > 0){
 			subcommandName = args[0].toLowerCase();
 		} else {

--- a/src/main/java/me/botsko/prism/commandlibs/Flag.java
+++ b/src/main/java/me/botsko/prism/commandlibs/Flag.java
@@ -13,7 +13,7 @@ public enum Flag {
 	SHARE("-share=player1[,player2...]", "Share a lookup result with another player."),
 	PASTE("Share your results with a pastebin service and return the link");
 	
-	private String description;
+	private final String description;
 	private String usage;
 	
 	

--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -1,14 +1,12 @@
 package me.botsko.prism.commandlibs;
 
-import java.util.HashMap;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.regex.Matcher;
 
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
-import me.botsko.prism.parameters.FlagParameter;
 import me.botsko.prism.parameters.PrismParameterHandler;
 
 import org.bukkit.command.CommandSender;
@@ -44,7 +42,8 @@ public class PreprocessArgs {
 		HashMap<String,PrismParameterHandler> registeredParams = Prism.getParameters();
 		
 		// Store names of matched params/handlers
-		HashMap<String,Matcher> foundArgs = new HashMap<String,Matcher>();
+		Set<String> foundArgsNames = new HashSet<String>();
+		List<MatchedParam> foundArgsList = new ArrayList<MatchedParam>();
 		
 		// Iterate all command arguments
 		if(args != null){
@@ -57,34 +56,11 @@ public class PreprocessArgs {
 				
 				// Match command argument to parameter handler
 				for( Entry<String,PrismParameterHandler> entry : registeredParams.entrySet() ){
-					Matcher m = entry.getValue().getArgumentPattern().matcher(arg);
-					if( m.matches() ){
-						
-						Prism.debug("Parameter regex "+entry.getValue().getArgumentPattern().pattern()+" has " + m.groupCount() + " matches:" );
-						for( int z = 0; z < m.groupCount()+1; z++ ){
-							Prism.debug("match " + z + ": " + m.group(z));
-						}
-
-						if( m.groupCount() < 2 ){
-							if( sender != null ) sender.sendMessage( Prism.messenger.playerError("Invalid syntax for parameter " + arg) );
-							return null;
-						}
-
-						if( m.group(2).isEmpty() ){
-							if( sender != null ) sender.sendMessage( Prism.messenger.playerError("Can't use empty values for '"+arg+"'. Use /prism ? for help.") );
-							return null;
-						}
-						
+					if(entry.getValue().applicable(parameters, arg, sender)) {
 						handlerFound = true;
-						if(entry.getValue() instanceof FlagParameter){
-							foundArgs.put(entry.getValue().getName().toLowerCase() + "/" + m.group(2).toLowerCase(), m);
-						} else {
-							foundArgs.put( entry.getValue().getName().toLowerCase(), m );
-						}
-						continue;
-
+						foundArgsList.add(new MatchedParam(entry.getValue(), arg));
+						foundArgsNames.add(entry.getValue().getName());
 					} else {
-						
 						// We support an alternate player syntax so that people can use the tab-complete
 						// feature of minecraft. Using p: prevents it.
 						Player autoFillPlayer = plugin.getServer().getPlayer(arg);
@@ -105,10 +81,10 @@ public class PreprocessArgs {
 					return null;
 				}
 			}
-			parameters.setFoundArgs( foundArgs );
+			parameters.setFoundArgs( foundArgsNames );
 			
 			// Reject no matches
-			if( foundArgs.isEmpty() ){
+			if( foundArgsList.isEmpty() ){
 				if( sender != null ) sender.sendMessage( Prism.messenger.playerError("You're missing valid parameters. Use /prism ? for assistance.") );
 				return null;
 			}
@@ -118,7 +94,7 @@ public class PreprocessArgs {
 			 */
 			if( useDefaults ){
 				for( Entry<String,PrismParameterHandler> entry : registeredParams.entrySet() ){
-					if( !foundArgs.containsKey(entry.getKey()) ){
+					if( !foundArgsNames.contains(entry.getKey()) ){
 						entry.getValue().defaultTo(parameters, sender);
 					}
 				}
@@ -127,10 +103,10 @@ public class PreprocessArgs {
 			/**
 			 * Send arguments to parameter handlers
 			 */
-			for( Entry<String,Matcher> entry : foundArgs.entrySet() ){
+			for (MatchedParam matchedParam : foundArgsList) {
 				try {
-					PrismParameterHandler handler = registeredParams.get(entry.getKey().replaceFirst("\\/.*", ""));
-					handler.process( parameters, entry.getValue(), sender );
+					PrismParameterHandler handler = matchedParam.getHandler();
+					handler.process( parameters, matchedParam.getArg(), sender );
 				} catch ( IllegalArgumentException e ){
 					if( sender != null ) sender.sendMessage( Prism.messenger.playerError(e.getMessage()) );
 					return null;
@@ -143,5 +119,23 @@ public class PreprocessArgs {
 			}
 		}
 		return parameters;
+	}
+
+	private static class MatchedParam {
+		private final PrismParameterHandler handler;
+		private final String arg;
+
+		public MatchedParam(PrismParameterHandler handler, String arg) {
+			this.handler = handler;
+			this.arg = arg;
+		}
+
+		public PrismParameterHandler getHandler() {
+			return handler;
+		}
+
+		public String getArg() {
+			return arg;
+		}
 	}
 }

--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -114,7 +114,7 @@ public class PreprocessArgs {
 			}
 			
 			// Player location
-			if( player != null && !plugin.getConfig().getBoolean("prism.queries.never-use-defaults") && parameters.getPlayerLocation() == null ){
+			if( player != null && !plugin.getConfig().getBoolean("prism.queries.never-use-defaults") && parameters.getPlayerLocation() == null && (parameters.getMaxLocation() == null || parameters.getMinLocation() == null) ){
 				parameters.setMinMaxVectorsFromPlayerLocation( player.getLocation() );
 			}
 		}

--- a/src/main/java/me/botsko/prism/commands/AboutCommand.java
+++ b/src/main/java/me/botsko/prism/commands/AboutCommand.java
@@ -11,7 +11,7 @@ public class AboutCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/DeleteCommand.java
+++ b/src/main/java/me/botsko/prism/commands/DeleteCommand.java
@@ -22,7 +22,7 @@ public class DeleteCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/commands/DrainCommand.java
+++ b/src/main/java/me/botsko/prism/commands/DrainCommand.java
@@ -17,7 +17,7 @@ public class DrainCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/ExtinguishCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ExtinguishCommand.java
@@ -15,7 +15,7 @@ public class ExtinguishCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/LookupCommand.java
+++ b/src/main/java/me/botsko/prism/commands/LookupCommand.java
@@ -24,7 +24,7 @@ public class LookupCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/NearCommand.java
+++ b/src/main/java/me/botsko/prism/commands/NearCommand.java
@@ -18,7 +18,7 @@ public class NearCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/PageCommand.java
+++ b/src/main/java/me/botsko/prism/commands/PageCommand.java
@@ -19,7 +19,7 @@ public class PageCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**
@@ -56,7 +56,7 @@ public class PageCommand implements SubHandler {
 		}
 		
 		// Determine page number
-		int page = 1;
+		int page;
 		if( TypeUtils.isNumeric( call.getArg(1) ) ){
 			page = Integer.parseInt(call.getArg(1));
 		} else {

--- a/src/main/java/me/botsko/prism/commands/PreviewCommand.java
+++ b/src/main/java/me/botsko/prism/commands/PreviewCommand.java
@@ -21,7 +21,7 @@ public class PreviewCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/ReportCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ReportCommand.java
@@ -25,7 +25,7 @@ public class ReportCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**
@@ -152,7 +152,7 @@ public class ReportCommand implements SubHandler {
 			sender.sendMessage( Prism.messenger.playerError( "Error: " + e.getMessage()) );
 	    	e.printStackTrace();
         } finally {
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 	}
 	
@@ -227,9 +227,9 @@ public class ReportCommand implements SubHandler {
 		        	//
 		        	e.printStackTrace();
 		        } finally {
-		        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-		        	if(s != null) try { s.close(); } catch (SQLException e) {}
-		        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+		        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+		        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+		        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
 		        }
 			}
 		});
@@ -289,9 +289,9 @@ public class ReportCommand implements SubHandler {
 		        } catch (SQLException e) {
 		        	e.printStackTrace();
 		        } finally {
-		        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-		        	if(s != null) try { s.close(); } catch (SQLException e) {}
-		        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+		        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+		        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+		        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
 		        }
 			}
 		});

--- a/src/main/java/me/botsko/prism/commands/ResetmyCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ResetmyCommand.java
@@ -13,7 +13,7 @@ public class ResetmyCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**
@@ -40,40 +40,37 @@ public class ResetmyCommand implements SubHandler {
 		/**
 		 * Inspector wand
 		 */
-		if( setType.equalsIgnoreCase("wand") ){
-			
-			// Ensure it's enabled
-			if( !plugin.getConfig().getBoolean("prism.wands.allow-user-override") ){
-				call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but personalizing the wand is currently not allowed.") );
-			}
-			
-			// Check for any wand permissions. @todo There should be some central way to handle this - some way to centralize it at least
-			if( !call.getPlayer().hasPermission("prism.rollback") 
-				&& !call.getPlayer().hasPermission("prism.restore")
-				&& !call.getPlayer().hasPermission("prism.wand.*")
-				&& !call.getPlayer().hasPermission("prism.wand.inspect")
-				&& !call.getPlayer().hasPermission("prism.wand.profile")
-				&& !call.getPlayer().hasPermission("prism.wand.rollback")
-				&& !call.getPlayer().hasPermission("prism.wand.restore")){
-				call.getPlayer().sendMessage( Prism.messenger.playerError("You do not have permission for this.") );
-				return;
-			}
-			
-			// Disable any current wand
-			if(Prism.playersWithActiveTools.containsKey(call.getPlayer().getName())){
-				Wand oldwand = Prism.playersWithActiveTools.get(call.getPlayer().getName());
-				oldwand.disable( call.getPlayer() );
-				Prism.playersWithActiveTools.remove(call.getPlayer().getName());
-				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Current wand " + ChatColor.RED + "disabled"+ChatColor.WHITE+".") );
-			}
-			
-			Settings.deleteSetting( "wand.item", call.getPlayer() );
-			Settings.deleteSetting( "wand.mode", call.getPlayer() );
-			call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Your personal wand settings have been reset to server defaults.") );
+		if (setType != null && !setType.equalsIgnoreCase("wand")) {
+			call.getPlayer().sendMessage(Prism.messenger.playerError("Invalid arguments. Use /prism ? for help."));
 			return;
-	
-		} else {
-			call.getPlayer().sendMessage( Prism.messenger.playerError("Invalid arguments. Use /prism ? for help.") );
 		}
-	}
+
+		if( !plugin.getConfig().getBoolean("prism.wands.allow-user-override") ){
+            call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but personalizing the wand is currently not allowed.") );
+        }
+
+        // Check for any wand permissions. @todo There should be some central way to handle this - some way to centralize it at least
+        if( !call.getPlayer().hasPermission("prism.rollback")
+            && !call.getPlayer().hasPermission("prism.restore")
+            && !call.getPlayer().hasPermission("prism.wand.*")
+            && !call.getPlayer().hasPermission("prism.wand.inspect")
+            && !call.getPlayer().hasPermission("prism.wand.profile")
+            && !call.getPlayer().hasPermission("prism.wand.rollback")
+            && !call.getPlayer().hasPermission("prism.wand.restore")){
+            call.getPlayer().sendMessage( Prism.messenger.playerError("You do not have permission for this.") );
+            return;
+        }
+
+        // Disable any current wand
+        if(Prism.playersWithActiveTools.containsKey(call.getPlayer().getName())){
+            Wand oldwand = Prism.playersWithActiveTools.get(call.getPlayer().getName());
+            oldwand.disable( call.getPlayer() );
+            Prism.playersWithActiveTools.remove(call.getPlayer().getName());
+            call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Current wand " + ChatColor.RED + "disabled"+ChatColor.WHITE+".") );
+        }
+
+        Settings.deleteSetting("wand.item", call.getPlayer());
+        Settings.deleteSetting( "wand.mode", call.getPlayer() );
+        call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Your personal wand settings have been reset to server defaults.") );
+    }
 }

--- a/src/main/java/me/botsko/prism/commands/RestoreCommand.java
+++ b/src/main/java/me/botsko/prism/commands/RestoreCommand.java
@@ -20,7 +20,7 @@ public class RestoreCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/RollbackCommand.java
+++ b/src/main/java/me/botsko/prism/commands/RollbackCommand.java
@@ -18,7 +18,7 @@ public class RollbackCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/SetmyCommand.java
+++ b/src/main/java/me/botsko/prism/commands/SetmyCommand.java
@@ -17,7 +17,7 @@ public class SetmyCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**
@@ -44,117 +44,116 @@ public class SetmyCommand implements SubHandler {
 		/**
 		 * Inspector wand
 		 */
-		if( setType.equalsIgnoreCase("wand") ){
-			
-			// Ensure it's enabled
-			if( !plugin.getConfig().getBoolean("prism.wands.allow-user-override") ){
-				call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but personalizing the wand is currently not allowed.") );
-			}
-			
-			// Check for any wand permissions. @todo There should be some central way to handle this - some way to centralize it at least
-			if( !call.getPlayer().hasPermission("prism.rollback") 
-				&& !call.getPlayer().hasPermission("prism.restore")
-				&& !call.getPlayer().hasPermission("prism.wand.*")
-				&& !call.getPlayer().hasPermission("prism.wand.inspect")
-				&& !call.getPlayer().hasPermission("prism.wand.profile")
-				&& !call.getPlayer().hasPermission("prism.wand.rollback")
-				&& !call.getPlayer().hasPermission("prism.wand.restore")){
-				call.getPlayer().sendMessage( Prism.messenger.playerError("You do not have permission for this.") );
-				return;
-			}
-			
-			// Disable any current wand
-			if(Prism.playersWithActiveTools.containsKey(call.getPlayer().getName())){
-				Wand oldwand = Prism.playersWithActiveTools.get(call.getPlayer().getName());
-				oldwand.disable( call.getPlayer() );
-				Prism.playersWithActiveTools.remove(call.getPlayer().getName());
-				call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Current wand " + ChatColor.RED + "disabled"+ChatColor.WHITE+".") );
-			}
-			
-			String setSubType = null;
-			if(call.getArgs().length >= 3){
-				setSubType = call.getArg(2);
-			}
-			
-			
-			/**
-			 * Set your custom wand mode to "hand", "item", or "block"
-			 */
-			if( setSubType.equalsIgnoreCase("mode") ){
-				
-				String setWandMode = null;
-				if(call.getArgs().length >= 4){
-					setWandMode = call.getArg(3);
-				}
-				if( setWandMode != null && (setWandMode.equals("hand") || setWandMode.equals("item") || setWandMode.equals("block")) ){
-					Settings.saveSetting("wand.mode", setWandMode, call.getPlayer());
-					// Delete the item so we don't confuse people.
-					Settings.deleteSetting( "wand.item", call.getPlayer() );
-					call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Changed your personal wand to " + ChatColor.GREEN + setWandMode + ChatColor.WHITE + " mode.") );
-					return;
-				}
-				call.getPlayer().sendMessage( Prism.messenger.playerError("Invalid arguments. Use /prism ? for help.") );
-				return;
-			}
-			
-			
-			/**
-			 * Set your custom wand item for either "item"
-			 * or "block" modes
-			 */
-			if( setSubType.equalsIgnoreCase("item") ){
-				String setWandItem = null;
-				if(call.getArgs().length >= 4){
-					setWandItem = call.getArg(3);
-				}
-				if( setWandItem != null){
-					
-					// If non-numeric, check for name
-					if( !TypeUtils.isNumeric( setWandItem ) ){
-						ArrayList<int[]> itemIds = Prism.getItems().getIdsByAlias( setWandItem );
-						if(itemIds.size() > 0){
-							int[] ids = itemIds.get(0);
-							setWandItem = ids[0]+":"+ids[1];
-						} else {
-							call.getPlayer().sendMessage( Prism.messenger.playerError("There's no item matching that name.") );
-							return;
-						}
-					}
-	
-					// Standardize
-					if(!setWandItem.contains(":")){
-						setWandItem += ":0";
-					}
-
-					int item_id = -1;
-					byte item_subid = 0;
-					
-					String[] itemIds = setWandItem.split(":");
-					if(itemIds.length == 2){
-						item_id = Integer.parseInt(itemIds[0]);
-						item_subid = Byte.parseByte(itemIds[1]);
-					}
-					if( item_id > -1 ){
-						String item_name = Prism.getItems().getAlias(item_id, item_subid);
-						if( item_name != null ){
-							
-							if( !ItemUtils.isAcceptableWand( item_id, item_subid ) ){
-								call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but you may not use " + item_name + " for a wand.") );
-								return;
-							}
-							
-							Settings.saveSetting("wand.item", setWandItem, call.getPlayer());
-							call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Changed your personal wand item to " + ChatColor.GREEN + item_name + ChatColor.WHITE + ".") );
-							return;
-							
-						}
-					}
-				}
-				call.getPlayer().sendMessage( Prism.messenger.playerError("Invalid arguments. Use /prism ? for help.") );
-				return;
-			}
-		} else {
-			call.getPlayer().sendMessage( Prism.messenger.playerError("Invalid arguments. Use /prism ? for help.") );
+		if (setType != null && !setType.equalsIgnoreCase("wand")) {
+			call.getPlayer().sendMessage(Prism.messenger.playerError("Invalid arguments. Use /prism ? for help."));
+			return;
 		}
-	}
+
+		if( !plugin.getConfig().getBoolean("prism.wands.allow-user-override") ){
+            call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but personalizing the wand is currently not allowed.") );
+        }
+
+        // Check for any wand permissions. @todo There should be some central way to handle this - some way to centralize it at least
+        if( !call.getPlayer().hasPermission("prism.rollback")
+            && !call.getPlayer().hasPermission("prism.restore")
+            && !call.getPlayer().hasPermission("prism.wand.*")
+            && !call.getPlayer().hasPermission("prism.wand.inspect")
+            && !call.getPlayer().hasPermission("prism.wand.profile")
+            && !call.getPlayer().hasPermission("prism.wand.rollback")
+            && !call.getPlayer().hasPermission("prism.wand.restore")){
+            call.getPlayer().sendMessage( Prism.messenger.playerError("You do not have permission for this.") );
+            return;
+        }
+
+        // Disable any current wand
+        if(Prism.playersWithActiveTools.containsKey(call.getPlayer().getName())){
+            Wand oldwand = Prism.playersWithActiveTools.get(call.getPlayer().getName());
+            oldwand.disable( call.getPlayer() );
+            Prism.playersWithActiveTools.remove(call.getPlayer().getName());
+            call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Current wand " + ChatColor.RED + "disabled"+ChatColor.WHITE+".") );
+        }
+
+        String setSubType = null;
+        if(call.getArgs().length >= 3){
+            setSubType = call.getArg(2);
+        }
+
+
+        /**
+         * Set your custom wand mode to "hand", "item", or "block"
+         */
+		if (setSubType != null && setSubType.equalsIgnoreCase("mode")) {
+
+			String setWandMode = null;
+			if (call.getArgs().length >= 4) {
+				setWandMode = call.getArg(3);
+			}
+			if (setWandMode != null && (setWandMode.equals("hand") || setWandMode.equals("item") || setWandMode.equals("block"))) {
+				Settings.saveSetting("wand.mode", setWandMode, call.getPlayer());
+				// Delete the item so we don't confuse people.
+				Settings.deleteSetting("wand.item", call.getPlayer());
+				call.getPlayer().sendMessage(Prism.messenger.playerHeaderMsg("Changed your personal wand to " + ChatColor.GREEN + setWandMode + ChatColor.WHITE + " mode."));
+				return;
+			}
+			call.getPlayer().sendMessage(Prism.messenger.playerError("Invalid arguments. Use /prism ? for help."));
+			return;
+		}
+
+
+		/**
+         * Set your custom wand item for either "item"
+         * or "block" modes
+         */
+        if (!setSubType.equalsIgnoreCase("item")) {
+            return;
+        }
+        String setWandItem = null;
+        if(call.getArgs().length >= 4){
+            setWandItem = call.getArg(3);
+        }
+        if( setWandItem != null){
+
+            // If non-numeric, check for name
+            if( !TypeUtils.isNumeric(setWandItem) ){
+                ArrayList<int[]> itemIds = Prism.getItems().getIdsByAlias( setWandItem );
+                if(itemIds.size() > 0){
+                    int[] ids = itemIds.get(0);
+                    setWandItem = ids[0]+":"+ids[1];
+                } else {
+                    call.getPlayer().sendMessage( Prism.messenger.playerError("There's no item matching that name.") );
+                    return;
+                }
+            }
+
+            // Standardize
+            if(!setWandItem.contains(":")){
+                setWandItem += ":0";
+            }
+
+            int item_id = -1;
+            byte item_subid = 0;
+
+            String[] itemIds = setWandItem.split(":");
+            if(itemIds.length == 2){
+                item_id = Integer.parseInt(itemIds[0]);
+                item_subid = Byte.parseByte(itemIds[1]);
+            }
+            if( item_id > -1 ){
+                String item_name = Prism.getItems().getAlias(item_id, item_subid);
+                if( item_name != null ){
+
+                    if( !ItemUtils.isAcceptableWand(item_id, item_subid) ){
+                        call.getPlayer().sendMessage( Prism.messenger.playerError("Sorry, but you may not use " + item_name + " for a wand.") );
+                        return;
+                    }
+
+                    Settings.saveSetting("wand.item", setWandItem, call.getPlayer());
+                    call.getPlayer().sendMessage( Prism.messenger.playerHeaderMsg("Changed your personal wand item to " + ChatColor.GREEN + item_name + ChatColor.WHITE + ".") );
+                    return;
+
+                }
+            }
+        }
+        call.getPlayer().sendMessage( Prism.messenger.playerError("Invalid arguments. Use /prism ? for help.") );
+    }
 }

--- a/src/main/java/me/botsko/prism/commands/TeleportCommand.java
+++ b/src/main/java/me/botsko/prism/commands/TeleportCommand.java
@@ -19,7 +19,7 @@ public class TeleportCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**
@@ -48,15 +48,13 @@ public class TeleportCommand implements SubHandler {
 		}
 		
 		// Parse the incoming ident
-		String ident = "";
-		if( call.getArg(1).contains("id:") ){
-			ident = call.getArg(1).replace("id:", "");
-		} else {
-			ident = call.getArg(1);
+		String ident = call.getArg(1);
+		if( ident.contains("id:") ){
+			ident = ident.replace("id:", "");
 		}
 		
 		// Determine result index to tp to - either an id, or the next/previous id
-		int record_id = 1;
+		int record_id;
 		if( ident.equals("next") || ident.equals("prev") ){
 			// Get stored results
 			QueryResult results = plugin.cachedQueries.get( keyName );
@@ -84,7 +82,7 @@ public class TeleportCommand implements SubHandler {
 		}
 		
 		// If a record id provided, re-query the database
-		Handler destinationAction = null;
+		Handler destinationAction;
 		if( call.getArg(1).contains("id:") ){
 				
 			// Build params

--- a/src/main/java/me/botsko/prism/commands/UndoCommand.java
+++ b/src/main/java/me/botsko/prism/commands/UndoCommand.java
@@ -24,7 +24,7 @@ public class UndoCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/ViewCommand.java
+++ b/src/main/java/me/botsko/prism/commands/ViewCommand.java
@@ -15,7 +15,7 @@ public class ViewCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/WandCommand.java
+++ b/src/main/java/me/botsko/prism/commands/WandCommand.java
@@ -22,7 +22,7 @@ public class WandCommand implements SubHandler {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/commands/WhatCommand.java
+++ b/src/main/java/me/botsko/prism/commands/WhatCommand.java
@@ -27,10 +27,8 @@ public class WhatCommand extends Executor {
 	 * 
 	 */
 	private void setupCommands() {
-		
-		final Prism prism = (Prism) plugin;
-		
-		
+
+
 		/**
 		 * /prism about
 		 */

--- a/src/main/java/me/botsko/prism/database/QueryBuilder.java
+++ b/src/main/java/me/botsko/prism/database/QueryBuilder.java
@@ -11,12 +11,12 @@ abstract public class QueryBuilder {
 	/**
 	 * 
 	 */
-	protected Prism plugin;
+	protected final Prism plugin;
 	protected List<String> columns = new ArrayList<String>();
 	protected List<String> conditions = new ArrayList<String>();
 	
-	protected String tableNameData = "prism_data";
-	protected String tableNameDataExtra = "prism_data_extra";
+	protected final String tableNameData = "prism_data";
+	protected final String tableNameDataExtra = "prism_data_extra";
 	
 	protected QueryParameters parameters;
 	protected boolean shouldGroup;

--- a/src/main/java/me/botsko/prism/database/mysql/SelectQueryBuilder.java
+++ b/src/main/java/me/botsko/prism/database/mysql/SelectQueryBuilder.java
@@ -261,7 +261,7 @@ public class SelectQueryBuilder extends QueryBuilder {
 			String coordCond = "(";
 			int l = 0;
 			for( Location loc : locations ){
-				coordCond += (l > 0 ? " OR" : "" ) + " ("+tableNameData+".x = " +(int)loc.getBlockX()+ " AND "+tableNameData+".y = " +(int)loc.getBlockY()+ " AND "+tableNameData+".z = " +(int)loc.getBlockZ() + ")";
+				coordCond += (l > 0 ? " OR" : "" ) + " ("+tableNameData+".x = " + loc.getBlockX() + " AND "+tableNameData+".y = " + loc.getBlockY() + " AND "+tableNameData+".z = " + loc.getBlockZ() + ")";
 				l++;
 			}
 			coordCond += ")";

--- a/src/main/java/me/botsko/prism/events/BlockStateChange.java
+++ b/src/main/java/me/botsko/prism/events/BlockStateChange.java
@@ -7,12 +7,12 @@ public class BlockStateChange {
 	/**
      * 
      */
-    private BlockState originalBlock;
+    private final BlockState originalBlock;
     
     /**
      * 
      */
-    private BlockState newBlock;
+    private final BlockState newBlock;
     
     
     /**

--- a/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
@@ -41,7 +41,7 @@ public class PrismBlockEvents implements Listener {
 	/**
 	 *
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 
 
 	/**

--- a/src/main/java/me/botsko/prism/listeners/PrismBlockPhysicsEvent.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismBlockPhysicsEvent.java
@@ -19,7 +19,7 @@ public class PrismBlockPhysicsEvent implements Listener {
 	/**
 	 *
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 
 
 	/**

--- a/src/main/java/me/botsko/prism/listeners/PrismCustomEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismCustomEvents.java
@@ -16,7 +16,7 @@ public class PrismCustomEvents implements Listener {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 
 	
 	/**

--- a/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
@@ -57,7 +57,7 @@ public class PrismEntityEvents implements Listener {
 	/**
 	 *
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 
 
 	/**
@@ -114,7 +114,7 @@ public class PrismEntityEvents implements Listener {
 
 				if( entity instanceof Horse ){
 					Horse horse = (Horse) entity;
-					if( horse.isCarryingChest() ){;
+					if( horse.isCarryingChest() ){
 						// Log item drops
 				        if( Prism.getIgnore().event("item-drop",entity.getWorld()) ){
 					        for( ItemStack i : horse.getInventory().getContents() ){
@@ -131,9 +131,8 @@ public class PrismEntityEvents implements Listener {
 					Player player = (Player) entityDamageByEntityEvent.getDamager();
 					if( !Prism.getIgnore().event("player-kill", player) ) return;
 					RecordingQueue.addToQueue( ActionFactory.create("player-kill", entity, player.getName()) );
-					return;
 
-				}
+                }
 				// Mob shot by an arrow from a player
 				else if(entityDamageByEntityEvent.getDamager() instanceof Arrow){
 					Arrow arrow = (Arrow) entityDamageByEntityEvent.getDamager();
@@ -142,9 +141,8 @@ public class PrismEntityEvents implements Listener {
 						Player player = (Player) arrow.getShooter();
 						if( !Prism.getIgnore().event("player-kill", player) ) return;
 						RecordingQueue.addToQueue( ActionFactory.create("player-kill", entity, player.getName()) );
-						return;
 
-					}
+                    }
 				} else {
 					// Mob died by another mob
 					Entity damager = entityDamageByEntityEvent.getDamager();
@@ -178,7 +176,7 @@ public class PrismEntityEvents implements Listener {
 	        if( Prism.getIgnore().event("player-death",p) ){
 		        String cause = DeathUtils.getCauseNiceName( p );
 		        String attacker = DeathUtils.getAttackerName( p );
-		        if(attacker == "pvpwolf"){
+		        if(attacker.equals("pvpwolf")){
 	            	String owner = DeathUtils.getTameWolfOwner(event);
 	            	attacker = owner+"'s wolf";
 	            }
@@ -498,7 +496,7 @@ public class PrismEntityEvents implements Listener {
 		Location loc = block.getLocation();
 		BlockState newState = event.getNewState();
 		String entity = event.getEntity().getType().name().toLowerCase();
-		RecordingQueue.addToQueue( ActionFactory.create("entity-form", loc, block.getTypeId(), (byte)block.getData(), newState.getTypeId(), (byte)newState.getRawData(), entity) );
+		RecordingQueue.addToQueue( ActionFactory.create("entity-form", loc, block.getTypeId(), block.getData(), newState.getTypeId(), newState.getRawData(), entity) );
 	}
 
 

--- a/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
@@ -28,7 +28,7 @@ public class PrismInventoryEvents implements Listener {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
@@ -43,17 +43,17 @@ public class PrismPlayerEvents implements Listener {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	/**
 	 * 
 	 */
-	private List<String> illegalCommands;
+	private final List<String> illegalCommands;
 	
 	/**
 	 * 
 	 */
-	private List<String> ignoreCommands;
+	private final List<String> ignoreCommands;
 	
 	
 	/**
@@ -347,7 +347,7 @@ public class PrismPlayerEvents implements Listener {
 		// Doors, buttons, containers, etc may only be opened with a right-click as of 1.4
 		if (block != null && event.getAction() == Action.RIGHT_CLICK_BLOCK){
 
-			String coord_key = null;
+			String coord_key;
 			switch (block.getType()){
 				case FURNACE:
 				case DISPENSER:

--- a/src/main/java/me/botsko/prism/listeners/PrismVehicleEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismVehicleEvents.java
@@ -21,7 +21,7 @@ public class PrismVehicleEvents implements Listener {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 
 	
 	/**

--- a/src/main/java/me/botsko/prism/measurement/Metrics.java
+++ b/src/main/java/me/botsko/prism/measurement/Metrics.java
@@ -47,7 +47,6 @@ import java.net.URLConnection;
 import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -396,25 +395,22 @@ public class Metrics {
         // Acquire a lock on the graphs, which lets us make the assumption we also lock everything
         // inside of the graph (e.g plotters)
         synchronized (graphs) {
-            final Iterator<Graph> iter = graphs.iterator();
 
-            while (iter.hasNext()) {
-                final Graph graph = iter.next();
+			for (Graph graph : graphs) {
+				for (Plotter plotter : graph.getPlotters()) {
+					// The key name to send to the metrics server
+					// The format is C-GRAPHNAME-PLOTTERNAME where separator - is defined at the top
+					// Legacy (R4) submitters use the format Custom%s, or CustomPLOTTERNAME
+					final String key = String.format("C%s%s%s%s", CUSTOM_DATA_SEPARATOR, graph.getName(), CUSTOM_DATA_SEPARATOR, plotter.getColumnName());
 
-                for (Plotter plotter : graph.getPlotters()) {
-                    // The key name to send to the metrics server
-                    // The format is C-GRAPHNAME-PLOTTERNAME where separator - is defined at the top
-                    // Legacy (R4) submitters use the format Custom%s, or CustomPLOTTERNAME
-                    final String key = String.format("C%s%s%s%s", CUSTOM_DATA_SEPARATOR, graph.getName(), CUSTOM_DATA_SEPARATOR, plotter.getColumnName());
+					// The value to send, which for the foreseeable future is just the string
+					// value of plotter.getValue()
+					final String value = Integer.toString(plotter.getValue());
 
-                    // The value to send, which for the foreseeable future is just the string
-                    // value of plotter.getValue()
-                    final String value = Integer.toString(plotter.getValue());
-
-                    // Add it to the http post data :)
-                    encodeDataPair(data, key, value);
-                }
-            }
+					// Add it to the http post data :)
+					encodeDataPair(data, key, value);
+				}
+			}
         }
 
         // Create the url
@@ -452,15 +448,12 @@ public class Metrics {
             // Is this the first update this hour?
             if (response.contains("OK This is your first update this hour")) {
                 synchronized (graphs) {
-                    final Iterator<Graph> iter = graphs.iterator();
 
-                    while (iter.hasNext()) {
-                        final Graph graph = iter.next();
-
-                        for (Plotter plotter : graph.getPlotters()) {
-                            plotter.reset();
-                        }
-                    }
+					for (Graph graph : graphs) {
+						for (Plotter plotter : graph.getPlotters()) {
+							plotter.reset();
+						}
+					}
                 }
             }
         }

--- a/src/main/java/me/botsko/prism/measurement/QueueStats.java
+++ b/src/main/java/me/botsko/prism/measurement/QueueStats.java
@@ -9,7 +9,7 @@ public class QueueStats {
 	/**
 	 * 
 	 */
-	protected ConcurrentSkipListMap<Long,Integer> perRunRecordingCounts = new ConcurrentSkipListMap<Long,Integer>();
+	protected final ConcurrentSkipListMap<Long,Integer> perRunRecordingCounts = new ConcurrentSkipListMap<Long,Integer>();
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/measurement/TimeTaken.java
+++ b/src/main/java/me/botsko/prism/measurement/TimeTaken.java
@@ -8,7 +8,7 @@ import me.botsko.prism.Prism;
 
 public class TimeTaken {
 	
-	protected Prism plugin;
+	protected final Prism plugin;
 	
 	
 	/**
@@ -23,7 +23,7 @@ public class TimeTaken {
 	/**
 	 * 
 	 */
-	protected TreeMap<Long,String> eventsTimed = new TreeMap<Long,String>();
+	protected final TreeMap<Long,String> eventsTimed = new TreeMap<Long,String>();
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/monitors/OreMonitor.java
+++ b/src/main/java/me/botsko/prism/monitors/OreMonitor.java
@@ -19,17 +19,17 @@ public class OreMonitor {
 	/**
 	 * 
 	 */
-	private final int threshhold_max = 100;
+	private final int threshold_max = 100;
 	
 	/**
 	 * 
 	 */
-	private int threshhold = 1;
+	private int threshold = 1;
 	
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	/**
 	 * 
@@ -68,7 +68,7 @@ public class OreMonitor {
 			
 		if(block != null && isWatched(block) && !plugin.alertedBlocks.containsKey( block.getLocation() )){
 			
-			threshhold = 1;
+			threshold = 1;
 			
 			// identify all ore blocks on same Y axis in x/z direction
 			ArrayList<Block> matchingBlocks = new ArrayList<Block>();
@@ -86,7 +86,7 @@ public class OreMonitor {
 				// Restore the block
 				block.setType( state.getType() );
 				
-				String count = foundores.size() + (foundores.size() >= threshhold_max ? "+" : "" );
+				String count = foundores.size() + (foundores.size() >= threshold_max ? "+" : "" );
 				final String msg = getOreColor(block) + player.getName() + " found " + count + " " + getOreNiceName(block) + " " + light + "% light";
 			
 				/**
@@ -157,11 +157,8 @@ public class OreMonitor {
 	 * @return
 	 */
 	protected boolean isWatched( Block block ){
-		if( Prism.getAlertedOres().containsKey( block.getTypeId() + ":" + block.getData() ) || Prism.getAlertedOres().containsKey( ""+block.getTypeId() ) ){
-			return true;
-		}
-		return false;
-	}
+        return Prism.getAlertedOres().containsKey(block.getTypeId() + ":" + block.getData()) || Prism.getAlertedOres().containsKey("" + block.getTypeId());
+    }
 	
 	
 	/**
@@ -182,8 +179,8 @@ public class OreMonitor {
 	        			Block newblock = currBlock.getRelative(x, y, z);
 	        			// ensure it matches the type and wasn't already found
 	        			if( newblock.getType() == type && !matchingBlocks.contains(newblock) ){
-	        				threshhold++;
-	        	        	if( threshhold <= threshhold_max ){
+	        				threshold++;
+	        	        	if( threshold <= threshold_max){
 	        	        		findNeighborBlocks( type, newblock, matchingBlocks );
 	        	        	}
 	        			}

--- a/src/main/java/me/botsko/prism/monitors/UseMonitor.java
+++ b/src/main/java/me/botsko/prism/monitors/UseMonitor.java
@@ -14,7 +14,7 @@ public class UseMonitor {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/parameters/ActionParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/ActionParameter.java
@@ -1,54 +1,24 @@
 package me.botsko.prism.parameters;
 
-import java.util.ArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.command.CommandSender;
-
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionType;
 import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
 import me.botsko.prism.utils.LevenshteinDistance;
+import org.bukkit.command.CommandSender;
 
-public class ActionParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Action";
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class ActionParameter extends SimplePrismParameterHandler {
+	public ActionParameter() {
+		super("Action", Pattern.compile("[~|!]?[\\w,-]+"), "a");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(a):([~|!]?[\\w,-]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
 		
-		String[] actions = input.group(2).split(",");
+		String[] actions = input.split(",");
 		if(actions.length > 0){
 			for(String action : actions){
 				// Find all actions that match the action provided - whether the full name or
@@ -82,13 +52,5 @@ public class ActionParameter implements PrismParameterHandler {
 				throw new IllegalArgumentException("Action parameter value not recognized. Try /pr ? for help");
 			}
 		}
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/BeforeParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/BeforeParameter.java
@@ -1,60 +1,23 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.command.CommandSender;
-
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.utils.DateUtil;
+import org.bukkit.command.CommandSender;
 
-public class BeforeParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Before";
+import java.util.regex.Pattern;
+
+public class BeforeParameter extends SimplePrismParameterHandler {
+	public BeforeParameter() {
+		super("Before", Pattern.compile("[\\w]+"));
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(before):([\\w]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		Long date = DateUtil.translateTimeStringToDate(input.group(2));
+
+	@Override
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
+		Long date = DateUtil.translateTimeStringToDate(input);
 		if(date != null){
 			query.setBeforeTime( date );
 		} else {
 			throw new IllegalArgumentException("Date/time for 'before' parameter value not recognized. Try /pr ? for help");
 		}
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/BlockParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/BlockParameter.java
@@ -1,52 +1,22 @@
 package me.botsko.prism.parameters;
 
-import java.util.ArrayList;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.command.CommandSender;
-
 import me.botsko.elixr.ItemUtils;
 import me.botsko.elixr.MaterialAliases;
 import me.botsko.elixr.TypeUtils;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.QueryParameters;
+import org.bukkit.command.CommandSender;
 
-public class BlockParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Block";
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+
+public class BlockParameter extends SimplePrismParameterHandler {
+	public BlockParameter() {
+		super("Block", Pattern.compile("[\\w,:]+"), "b");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(b):([\\w,:]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		String[] blocks = input.group(2).split(",");
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
+		String[] blocks = input.split(",");
 		
 		if(blocks.length > 0){
 			for(String b : blocks){
@@ -87,13 +57,5 @@ public class BlockParameter implements PrismParameterHandler {
 				}
 			}
 		}
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/EntityParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/EntityParameter.java
@@ -1,48 +1,18 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.command.CommandSender;
-
 import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
+import org.bukkit.command.CommandSender;
 
-public class EntityParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Entity";
+import java.util.regex.Pattern;
+
+public class EntityParameter extends SimplePrismParameterHandler {
+	public EntityParameter() {
+		super("Entity", Pattern.compile("[~|!]?[\\w,]+"), "e");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(e):([~|!]?[\\w,]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		String[] entityNames = input.group(2).split(",");
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
+		String[] entityNames = input.split(",");
 		if(entityNames.length > 0){
 			for(String entityName : entityNames){
 				MatchRule match = MatchRule.INCLUDE;
@@ -52,13 +22,5 @@ public class EntityParameter implements PrismParameterHandler {
 				query.addEntity( entityName.replace("!", ""), match );
 			}
 		}
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/FlagParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/FlagParameter.java
@@ -1,55 +1,43 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import me.botsko.elixr.TypeUtils;
+import me.botsko.prism.actionlibs.QueryParameters;
+import me.botsko.prism.commandlibs.Flag;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import me.botsko.elixr.TypeUtils;
-import me.botsko.prism.actionlibs.QueryParameters;
-import me.botsko.prism.commandlibs.Flag;
+import java.util.regex.Pattern;
 
 public class FlagParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Flags";
+	@Override
+	public String getName() {
+		return "Flag";
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
+
+	@Override
+	public String[] getHelp() {
+		return new String[0];
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(-)([^\\s]+)");
+
+	@Override
+	public boolean applicable(QueryParameters query, String parameter, CommandSender sender) {
+		return Pattern.compile("(-)([^\\s]+)").matcher(parameter).matches();
 	}
-	
-	
-	
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		
-		String[] flagComponents = input.group(2).split("=");
-		Flag flag = Flag.valueOf( flagComponents[0].replace("-", "_").toUpperCase() );
+
+	@Override
+	public void process(QueryParameters query, String parameter, CommandSender sender) {
+		String[] flagComponents = parameter.substring(1).split("=");
+		Flag flag;
+		try {
+			flag = Flag.valueOf( flagComponents[0].replace("-", "_").toUpperCase() );
+		} catch (IllegalArgumentException ex) {
+			throw new IllegalArgumentException("Flag -" + flagComponents[0] + " not found", ex);
+		}
 		if(!(query.hasFlag(flag))){
-				
+
 			query.addFlag(flag);
-			
+
 			// Flag has a value
 			if( flagComponents.length > 1 ){
 				if(flag.equals(Flag.PER_PAGE)){
@@ -74,12 +62,9 @@ public class FlagParameter implements PrismParameterHandler {
 			}
 		}
 	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
+
+	@Override
+	public void defaultTo(QueryParameters query, CommandSender sender) {
+
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/FlagParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/FlagParameter.java
@@ -53,7 +53,7 @@ public class FlagParameter implements PrismParameterHandler {
 						}
 						Player shareWith = Bukkit.getServer().getPlayer(sharePlayer);
 						if( shareWith != null ){
-							query.addSharedPlayer( (CommandSender)shareWith );
+							query.addSharedPlayer(shareWith);
 						} else {
 							throw new IllegalArgumentException( "Can't share with " + sharePlayer + ". Are they online?" );
 						}

--- a/src/main/java/me/botsko/prism/parameters/IdParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/IdParameter.java
@@ -1,59 +1,21 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.command.CommandSender;
-
 import me.botsko.elixr.TypeUtils;
 import me.botsko.prism.actionlibs.QueryParameters;
+import org.bukkit.command.CommandSender;
 
-public class IdParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "ID";
+import java.util.regex.Pattern;
+
+public class IdParameter extends SimplePrismParameterHandler {
+	public IdParameter() {
+		super("ID", Pattern.compile("[\\d,]+"));
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(id):([\\d,]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
 		
-		if( !TypeUtils.isNumeric( input.group(2) ) ){
+		if( !TypeUtils.isNumeric( input ) ){
 			throw new IllegalArgumentException("ID must be a number. Use /prism ? for help.");
 		}
-		query.setId( Integer.parseInt(input.group(2)) );
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
+		query.setId( Integer.parseInt(input) );
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/KeywordParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/KeywordParameter.java
@@ -1,54 +1,16 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import me.botsko.prism.actionlibs.QueryParameters;
 import org.bukkit.command.CommandSender;
 
-import me.botsko.prism.actionlibs.QueryParameters;
+import java.util.regex.Pattern;
 
-public class KeywordParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Keyword";
+public class KeywordParameter extends SimplePrismParameterHandler {
+	public KeywordParameter() {
+		super("Keyword", Pattern.compile("[^\\s]+"), "k");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(k):([^\\s]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		query.setKeyword( input.group(2) );
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
+		query.setKeyword( input );
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/PlayerParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/PlayerParameter.java
@@ -1,48 +1,18 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.command.CommandSender;
-
 import me.botsko.prism.actionlibs.MatchRule;
 import me.botsko.prism.actionlibs.QueryParameters;
+import org.bukkit.command.CommandSender;
 
-public class PlayerParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Player";
+import java.util.regex.Pattern;
+
+public class PlayerParameter extends SimplePrismParameterHandler {
+	public PlayerParameter() {
+		super("Player", Pattern.compile("[~|!]?[\\w,]+"), "p");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(p):([~|!]?[\\w,]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		String[] playerNames = input.group(2).split(",");
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
+		String[] playerNames = input.split(",");
 		if(playerNames.length > 0){
 			for(String playerName : playerNames){
 				MatchRule match = MatchRule.INCLUDE;
@@ -57,13 +27,5 @@ public class PlayerParameter implements PrismParameterHandler {
 				query.addPlayerName( playerName, match );
 			}
 		}
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void defaultTo( QueryParameters query, CommandSender sender ){
-		return;
 	}
 }

--- a/src/main/java/me/botsko/prism/parameters/PrismParameterHandler.java
+++ b/src/main/java/me/botsko/prism/parameters/PrismParameterHandler.java
@@ -1,22 +1,18 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.command.CommandSender;
-
 import me.botsko.prism.actionlibs.QueryParameters;
+import org.bukkit.command.CommandSender;
 
 public interface PrismParameterHandler {
 	
 	public String getName();
-	
+
 	public String[] getHelp();
-	
-	public Pattern getArgumentPattern();
-	
-	public void process( QueryParameters query, Matcher input, CommandSender sender );
-	
+
+	public boolean applicable(QueryParameters query, String parameter, CommandSender sender);
+
+	public void process(QueryParameters query, String parameter, CommandSender sender);
+
 	public void defaultTo( QueryParameters query, CommandSender sender );
 
 }

--- a/src/main/java/me/botsko/prism/parameters/RadiusParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/RadiusParameter.java
@@ -1,15 +1,5 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Chunk;
-import org.bukkit.Location;
-import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.entity.Player;
-
 import me.botsko.elixr.ChunkUtils;
 import me.botsko.elixr.TypeUtils;
 import me.botsko.prism.Prism;
@@ -17,48 +7,28 @@ import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
 import me.botsko.prism.bridge.WorldEditBridge;
 import me.botsko.prism.utils.MiscUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
 
-public class RadiusParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Radius";
+import java.util.regex.Pattern;
+
+public class RadiusParameter extends SimplePrismParameterHandler {
+	public RadiusParameter() {
+		super("Radius", Pattern.compile("[\\w,:-]+"), "r");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(r):([\\w,:-]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
 		
 		Player player = null;
 		if( sender instanceof Player ){
 			player = (Player)sender;
 		}
 		
-		String inputValue = input.group(2);
+		String inputValue = input;
 
 		FileConfiguration config = Bukkit.getPluginManager().getPlugin("Prism").getConfig();
 		
@@ -79,9 +49,9 @@ public class RadiusParameter implements PrismParameterHandler {
 						}
 					}
 					coordsLoc = (new Location(
-							player != null ? player.getWorld() : 
-							(query.getWorld() != null ? Bukkit.getServer().getWorld(query.getWorld()) : 
-							Bukkit.getServer().getWorlds().get(0)), 
+							player != null ? player.getWorld() :
+							(query.getWorld() != null ? Bukkit.getServer().getWorld(query.getWorld()) :
+							Bukkit.getServer().getWorlds().get(0)),
 							Integer.parseInt(coordinates[0]), 
 							Integer.parseInt(coordinates[1]), 
 							Integer.parseInt(coordinates[2])));

--- a/src/main/java/me/botsko/prism/parameters/RadiusParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/RadiusParameter.java
@@ -38,7 +38,7 @@ public class RadiusParameter extends SimplePrismParameterHandler {
 			if(inputValue.contains(":")){
 				desiredRadius = Integer.parseInt(inputValue.split(":")[1]);
 				String radiusLocOrPlayer = inputValue.split(":")[0];
-				if( radiusLocOrPlayer.contains(",") && player != null ){ // Cooridinates; x,y,z
+				if( radiusLocOrPlayer.contains(",") && player != null ){ // Coordinates; x,y,z
 					String[] coordinates = radiusLocOrPlayer.split(",");
 					if(coordinates.length != 3){
 						throw new IllegalArgumentException("Couldn't parse the coordinates '" + radiusLocOrPlayer + "'. Perhaps you have more than two commas?");
@@ -49,9 +49,7 @@ public class RadiusParameter extends SimplePrismParameterHandler {
 						}
 					}
 					coordsLoc = (new Location(
-							player != null ? player.getWorld() :
-							(query.getWorld() != null ? Bukkit.getServer().getWorld(query.getWorld()) :
-							Bukkit.getServer().getWorlds().get(0)),
+							player.getWorld(),
 							Integer.parseInt(coordinates[0]), 
 							Integer.parseInt(coordinates[1]), 
 							Integer.parseInt(coordinates[2])));
@@ -86,9 +84,7 @@ public class RadiusParameter extends SimplePrismParameterHandler {
 				if(coordsLoc != null){
 					query.setMinMaxVectorsFromPlayerLocation(coordsLoc); // We need to set this *after* the radius has been set or it won't work.
 				} else {
-					if( player != null ){
-						query.setMinMaxVectorsFromPlayerLocation( player.getLocation() );
-					}
+					query.setMinMaxVectorsFromPlayerLocation( player.getLocation() );
 				}
 			}
 		} else {
@@ -106,11 +102,9 @@ public class RadiusParameter extends SimplePrismParameterHandler {
 				} else {
 				
 					// Load a selection from world edit as our area.
-					if(player != null){
-						Prism prism = (Prism) Bukkit.getPluginManager().getPlugin("Prism");
-						if( !WorldEditBridge.getSelectedArea(prism, player, query) ){
-							throw new IllegalArgumentException("Invalid region selected. Make sure you have a region selected, and that it doesn't exceed the max radius.");
-						}
+					Prism prism = (Prism) Bukkit.getPluginManager().getPlugin("Prism");
+					if( !WorldEditBridge.getSelectedArea(prism, player, query) ){
+						throw new IllegalArgumentException("Invalid region selected. Make sure you have a region selected, and that it doesn't exceed the max radius.");
 					}
 				}
 			}
@@ -128,11 +122,11 @@ public class RadiusParameter extends SimplePrismParameterHandler {
 			// User wants no radius, but contained within the current world
 			else if(inputValue.equals("world")){
 				// Do they have permission to override the global lookup radius
-				if( query.getProcessType().equals(PrismProcessType.LOOKUP) && player != null && !player.hasPermission("prism.override-max-lookup-radius") ){
+				if(query.getProcessType().equals(PrismProcessType.LOOKUP) && !player.hasPermission("prism.override-max-lookup-radius")){
 					throw new IllegalArgumentException("You do not have permission to override the max radius.");
 				}
 				// Do they have permission to override the global applier radius
-				if( !query.getProcessType().equals(PrismProcessType.LOOKUP) && player != null && !player.hasPermission("prism.override-max-applier-radius") ){
+				if(!query.getProcessType().equals(PrismProcessType.LOOKUP) && !player.hasPermission("prism.override-max-applier-radius")){
 					throw new IllegalArgumentException("You do not have permission to override the max radius.");
 				}
 				// Use the world defined in the w: param
@@ -140,13 +134,8 @@ public class RadiusParameter extends SimplePrismParameterHandler {
 					inputValue = query.getWorld();
 				}
 				// Use the current world
-				else if(player != null){
-					inputValue = player.getWorld().getName();
-				} 
-				// Use the default world
 				else {
-//					sender.sendMessage(Prism.messenger.playerError( "Can't use the current world since you're not a player. Using default world." ));
-					inputValue = Bukkit.getServer().getWorlds().get(0).getName();
+					inputValue = player.getWorld().getName();
 				}
 				query.setWorld( inputValue );
 				query.setAllowNoRadius(true);
@@ -155,11 +144,11 @@ public class RadiusParameter extends SimplePrismParameterHandler {
 			// User has asked for a global radius
 			else if(inputValue.equals("global")){
 				// Do they have permission to override the global lookup radius
-				if( query.getProcessType().equals(PrismProcessType.LOOKUP) && player != null && !player.hasPermission("prism.override-max-lookup-radius") ){
+				if(query.getProcessType().equals(PrismProcessType.LOOKUP) && !player.hasPermission("prism.override-max-lookup-radius")){
 					throw new IllegalArgumentException("You do not have permission to override the max radius.");
 				}
 				// Do they have permission to override the global applier radius
-				if( !query.getProcessType().equals(PrismProcessType.LOOKUP) && player != null && !player.hasPermission("prism.override-max-applier-radius") ){
+				if(!query.getProcessType().equals(PrismProcessType.LOOKUP) && !player.hasPermission("prism.override-max-applier-radius")){
 					throw new IllegalArgumentException("You do not have permission to override the max radius.");
 				}
 				// Either they have permission or player is null

--- a/src/main/java/me/botsko/prism/parameters/SimplePrismParameterHandler.java
+++ b/src/main/java/me/botsko/prism/parameters/SimplePrismParameterHandler.java
@@ -1,0 +1,64 @@
+package me.botsko.prism.parameters;
+
+import me.botsko.prism.actionlibs.QueryParameters;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public abstract class SimplePrismParameterHandler implements PrismParameterHandler {
+	private final String name;
+	private final Pattern inputMatcher;
+	private final Set<String> aliases;
+
+	public SimplePrismParameterHandler(String name, String... aliases) {
+		this(name, null, aliases);
+	}
+
+	public SimplePrismParameterHandler(String name, Pattern inputMatcher, String... aliases) {
+		this.name = name;
+		this.inputMatcher = inputMatcher;
+		// Set aliases to name + aliases
+		this.aliases = new HashSet<String>(Arrays.asList(aliases));
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String[] getHelp() {
+		return new String[0];
+	}
+
+	protected abstract void process(QueryParameters query, String alias, String input, CommandSender sender);
+
+	@Override
+	public void process(QueryParameters query, String parameter, CommandSender sender) {
+		// Should never fail, applicable is called first
+		String[] split = parameter.split(":", 2);
+		String alias = split[0];
+		String input = split[1];
+		if(inputMatcher != null && !inputMatcher.matcher(input).matches()) {
+			throw new IllegalArgumentException("Invalid syntax for parameter " + input);
+		}
+		process(query, alias, input, sender);
+	}
+
+	@Override
+	public boolean applicable(QueryParameters query, String parameter, CommandSender sender) {
+		String[] split = parameter.split(":", 2);
+		if(split.length != 2)
+			return false;
+		String alias = split[0];
+		return aliases.contains(alias);
+	}
+
+	@Override
+	public void defaultTo(QueryParameters query, CommandSender sender) {
+
+	}
+}

--- a/src/main/java/me/botsko/prism/parameters/SinceParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/SinceParameter.java
@@ -1,55 +1,25 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.bukkit.Bukkit;
-import org.bukkit.command.CommandSender;
-import org.bukkit.configuration.file.FileConfiguration;
-
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.QueryParameters;
 import me.botsko.prism.appliers.PrismProcessType;
 import me.botsko.prism.utils.DateUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
 
-public class SinceParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "Since";
+import java.util.regex.Pattern;
+
+public class SinceParameter extends SimplePrismParameterHandler {
+	public SinceParameter() {
+		super("Since", Pattern.compile("[\\w]+"), "t");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(since|t):([\\w]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		if(input.group(2).equalsIgnoreCase("none")){
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
+		if(input.equalsIgnoreCase("none")){
 			query.setIgnoreTime(true);
 		} else {
-			Long date = DateUtil.translateTimeStringToDate(input.group(2));
+			Long date = DateUtil.translateTimeStringToDate(input);
 			if(date != null){
 				query.setSinceTime( date );
 			} else {
@@ -57,16 +27,12 @@ public class SinceParameter implements PrismParameterHandler {
 			}
 		}
 	}
-	
-	
-	/**
-	 * 
-	 */
+
 	public void defaultTo( QueryParameters query, CommandSender sender ){
 		
 		if( query.getProcessType().equals(PrismProcessType.DELETE) ) return;
 	
-		if( !query.getFoundArgs().containsKey("before") && !query.getFoundArgs().containsKey("since") ){
+		if( !query.getFoundArgs().contains("before") && !query.getFoundArgs().contains("since") ){
 			
 			FileConfiguration config = Bukkit.getPluginManager().getPlugin("Prism").getConfig();
 			

--- a/src/main/java/me/botsko/prism/parameters/WorldParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/WorldParameter.java
@@ -1,53 +1,23 @@
 package me.botsko.prism.parameters;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import me.botsko.prism.Prism;
+import me.botsko.prism.actionlibs.QueryParameters;
+import me.botsko.prism.appliers.PrismProcessType;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import me.botsko.prism.Prism;
-import me.botsko.prism.actionlibs.QueryParameters;
-import me.botsko.prism.appliers.PrismProcessType;
+import java.util.regex.Pattern;
 
-public class WorldParameter implements PrismParameterHandler {
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String getName(){
-		return "World";
+public class WorldParameter extends SimplePrismParameterHandler {
+	public WorldParameter() {
+		super("World", Pattern.compile("[^\\s]+"), "w");
 	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public String[] getHelp(){
-		return new String[]{};
-	}
-	
-	
-	/**
-	 * 
-	 * @return
-	 */
-	public Pattern getArgumentPattern(){
-		return Pattern.compile("(w):([^\\s]+)");
-	}
-	
-	
-	/**
-	 * 
-	 */
-	public void process( QueryParameters query, Matcher input, CommandSender sender ){
-		String worldName = input.group(2);
+
+	public void process(QueryParameters query, String alias, String input, CommandSender sender) {
+		String worldName = input;
 		if(worldName.equalsIgnoreCase("current")){
-			if( sender != null && sender instanceof Player ){
+			if( sender instanceof Player ){
 				worldName = ((Player)sender).getWorld().getName();
 			} else {
 				sender.sendMessage(Prism.messenger.playerError( "Can't use the current world since you're not a player. Using default world." ));
@@ -56,14 +26,10 @@ public class WorldParameter implements PrismParameterHandler {
 		}
 		query.setWorld( worldName );
 	}
-	
-	
-	/**
-	 * 
-	 */
+
 	public void defaultTo( QueryParameters query, CommandSender sender ){
 		if( query.getProcessType().equals(PrismProcessType.DELETE) ) return;
-		if( sender != null && sender instanceof Player && !query.allowsNoRadius()){
+		if( sender instanceof Player && !query.allowsNoRadius()){
 			query.setWorld( ((Player)sender).getWorld().getName() );
 		}
 	}

--- a/src/main/java/me/botsko/prism/purge/PurgeChunkingUtil.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeChunkingUtil.java
@@ -30,12 +30,12 @@ public class PurgeChunkingUtil {
     			id = rs.getInt(1);
 			}
             
-        } catch (SQLException e) {
+        } catch (SQLException ignored) {
         	
         } finally {
-        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 		return id;
 	}
@@ -61,12 +61,12 @@ public class PurgeChunkingUtil {
     			id = rs.getInt(1);
 			}
             
-        } catch (SQLException e) {
+        } catch (SQLException ignored) {
         	
         } finally {
-        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 		return id;
 	}

--- a/src/main/java/me/botsko/prism/purge/PurgeTask.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeTask.java
@@ -11,12 +11,12 @@ public class PurgeTask implements Runnable {
 	/**
 	 * 
 	 */
-	private Prism plugin;
+	private final Prism plugin;
 	
 	/**
 	 * 
 	 */
-	private CopyOnWriteArrayList<QueryParameters> paramList;
+	private final CopyOnWriteArrayList<QueryParameters> paramList;
 	
 	/**
 	 * 
@@ -26,7 +26,7 @@ public class PurgeTask implements Runnable {
 	/**
 	 * 
 	 */
-	private int purge_tick_delay;
+	private final int purge_tick_delay;
 	
 	/**
 	 * 
@@ -41,7 +41,7 @@ public class PurgeTask implements Runnable {
 	/**
 	 * 
 	 */
-	private PurgeCallback callback;
+	private final PurgeCallback callback;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/settings/Settings.java
+++ b/src/main/java/me/botsko/prism/settings/Settings.java
@@ -54,8 +54,8 @@ public class Settings {
 		} catch (SQLException e) {
 //			plugin.logDbError( e );
 		} finally {
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 	}
 	
@@ -100,8 +100,8 @@ public class Settings {
 		} catch (SQLException e) {
 //			plugin.logDbError( e );
 		} finally {
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 	}
 	
@@ -145,9 +145,9 @@ public class Settings {
         } catch (SQLException e) {
 //        	plugin.logDbError( e );
         } finally {
-        	if(rs != null) try { rs.close(); } catch (SQLException e) {}
-        	if(s != null) try { s.close(); } catch (SQLException e) {}
-        	if(conn != null) try { conn.close(); } catch (SQLException e) {}
+        	if(rs != null) try { rs.close(); } catch (SQLException ignored) {}
+        	if(s != null) try { s.close(); } catch (SQLException ignored) {}
+        	if(conn != null) try { conn.close(); } catch (SQLException ignored) {}
         }
 		return value;
 	}

--- a/src/main/java/me/botsko/prism/wands/QueryWandBase.java
+++ b/src/main/java/me/botsko/prism/wands/QueryWandBase.java
@@ -26,7 +26,7 @@ public abstract class QueryWandBase extends WandBase {
 	/**
 	 * Keep an instance of {@link me.botsko.prism.Prism Prism} to use.
 	 */
-	protected Prism plugin;
+	protected final Prism plugin;
 	
 	
 	/**

--- a/src/main/java/me/botsko/prism/wands/WandBase.java
+++ b/src/main/java/me/botsko/prism/wands/WandBase.java
@@ -131,7 +131,7 @@ public abstract class WandBase {
 	public void disable( Player player ){
 		PlayerInventory inv = player.getInventory();
 		if( itemWasGiven() ){
-			int itemSlot = -1;
+			int itemSlot;
 			// Likely is what they're holding
 			if( inv.getItemInHand().getTypeId() == item_id && inv.getItemInHand().getDurability() == item_subid ){
 				itemSlot = inv.getHeldItemSlot();


### PR DESCRIPTION
In 6c72ec4 PrismParameterHandler is now more flexible yet easier to use, especially when using the default implementation SimplePrismParameterHandler.

cbcbffc fixes an issue where the min and max vector would be overridden if the player location wasn't set in the query. Now it checks if min and max are already set.

9b3faf2 is the load of cleanups
