### PR TITLE
Misc Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,17 @@
     </resources>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.0.2</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <showDeprecation>false</showDeprecation>
+          <showWarnings>true</showWarnings>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.lukegb.mojo</groupId>
         <artifactId>gitdescribe-maven-plugin</artifactId>
         <version>1.3</version>

--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -330,6 +330,7 @@ public class Prism extends JavaPlugin {
 		illegalEntities = (ArrayList<String>) getConfig().getList("prism.appliers.never-spawn-entity");
 		
 		ConfigurationSection alertBlocks = getConfig().getConfigurationSection("prism.alerts.ores.blocks");
+		alertedOres.clear();
 		if( alertBlocks != null){
 			for( String key : alertBlocks.getKeys(false) ){
 				alertedOres.put( key, alertBlocks.getString(key));
@@ -342,6 +343,11 @@ public class Prism extends JavaPlugin {
 		items = new MaterialAliases();
 	}
 
+	@Override
+	public void reloadConfig() {
+		super.reloadConfig();
+		loadConfig();
+	}
 	
 	/**
 	 * 

--- a/src/main/java/me/botsko/prism/commands/PrismCommands.java
+++ b/src/main/java/me/botsko/prism/commands/PrismCommands.java
@@ -186,7 +186,6 @@ public class PrismCommands extends Executor {
 		.setHandler(new SubHandler() {
             public void handle(CallInfo call) {
             	prism.reloadConfig();
-            	Prism.config = plugin.getConfig();
 				call.getSender().sendMessage( Prism.messenger.playerHeaderMsg("Configuration reloaded successfully.") );
             }
 		});

--- a/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
@@ -32,12 +32,6 @@ public class PrismInventoryEvents implements Listener {
 
 	/**
 	 * 
-	 */
-	private InventoryClickEvent event;
-	
-	
-	/**
-	 * 
 	 * @param plugin
 	 */
 	public PrismInventoryEvents( Prism plugin ){
@@ -110,7 +104,6 @@ public class PrismInventoryEvents implements Listener {
 		
 		// Store some info
 		Player player = (Player) event.getWhoClicked();
-		this.event = event;
 		ItemStack currentitem = event.getCurrentItem();
 		ItemStack cursoritem = event.getCursor();
 
@@ -141,23 +134,34 @@ public class PrismInventoryEvents implements Listener {
     		// If BOTH items are not air then you've swapped an item. We need to record an insert for the cursor item and
     		// and remove for the current.
     		if( currentitem != null && !currentitem.getType().equals(Material.AIR) && cursoritem != null && !cursoritem.getType().equals(Material.AIR) ){
-    			recordInvAction( player, containerLoc, currentitem, event.getRawSlot(), "item-remove");
-    			recordInvAction( player, containerLoc, cursoritem, event.getRawSlot(), "item-insert");
+    			recordInvAction( player, containerLoc, currentitem, event.getRawSlot(), "item-remove", event);
+    			recordInvAction( player, containerLoc, cursoritem, event.getRawSlot(), "item-insert", event);
     		}
     		else if( currentitem != null && !currentitem.getType().equals(Material.AIR) ){
-		    	recordInvAction( player, containerLoc, currentitem, event.getRawSlot(), "item-remove");
+		    	recordInvAction( player, containerLoc, currentitem, event.getRawSlot(), "item-remove", event);
 		    }
     		else if( cursoritem != null && !cursoritem.getType().equals(Material.AIR) ){
-		    	recordInvAction( player, containerLoc, cursoritem, event.getRawSlot(), "item-insert");
+		    	recordInvAction( player, containerLoc, cursoritem, event.getRawSlot(), "item-insert", event);
 		    }
     		return;
     	}
     	if( event.isShiftClick() && cursoritem != null && cursoritem.getType().equals(Material.AIR) ){
-    		recordInvAction( player, containerLoc, currentitem, -1, "item-insert");
+    		recordInvAction( player, containerLoc, currentitem, -1, "item-insert", event);
     	}
 	}
 	
 	
+	/**
+	 *
+	 * @param player
+	 * @param item
+	 * @param slot
+	 * @param actionType
+	 */
+	protected void recordInvAction( Player player, Location containerLoc, ItemStack item, int slot, String actionType ){
+		recordInvAction(player, containerLoc, item, slot, actionType, null);
+	}
+
 	/**
 	 *
      * @param player
@@ -165,8 +169,7 @@ public class PrismInventoryEvents implements Listener {
      * @param slot
 	 * @param actionType
 	 */
-	protected void recordInvAction( Player player, Location containerLoc, ItemStack item, int slot, String actionType ){
-		
+	protected void recordInvAction( Player player, Location containerLoc, ItemStack item, int slot, String actionType, InventoryClickEvent event ){		
 		if( !Prism.getIgnore().event(actionType,player) ) return;
 		
 		// Determine correct quantity. Right-click events change the item
@@ -175,7 +178,7 @@ public class PrismInventoryEvents implements Listener {
 	    if(item != null){
 		    officialQuantity = item.getAmount();
 		    // If the player right-clicked we need to assume the amount
-		    if( event.isRightClick() ){
+		    if( event != null && event.isRightClick() ){
 		    	// If you're right-clicking to remove an item, it divides by two
 		    	if( actionType.equals("item-remove") ){
 		    		officialQuantity = (officialQuantity - (int)Math.floor( (item.getAmount() / 2) ));


### PR DESCRIPTION
1. On my platform, Maven wants to default to compiling Java source code to Java 1.3, which causes errors, so I made the pom.xml explicitly choose 1.6.
2. If the user reloads the config file at runtime using prism's reload command, the loadConfig() method didn't get called again, causing some values to not get reloaded correctly. The AlertedOres map wasn't cleared first either. I also made it so that the PrismCommand's reload handler doesn't intrude on the Prism object in setting its config member, and lets the Prism object handle that itself. `loadConfig()` is now called whenever `reloadConfig()` is called on Prism, so it makes it much more unlikely for the Prism object to possibly be left in an inconsistent regarding its loaded config.
3. It used to be that if the last InventoryClickEvent (from any player) was a right-click, then invalid values could be recorded for other inventory events. This commit is related to commit 904ec688e4f109b27e2d04b6e59f473717dab8a4, which fixed a bunch of similar issues, but missed this one.
