### PR TITLE
Ignore entities activating redstone ore blocks

### DIFF
--- a/src/main/java/me/botsko/prism/actionlibs/ActionFactory.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionFactory.java
@@ -39,7 +39,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, String player) {
+    public static Handler createBlock(String action_type, String player) {
         final BlockAction a = new BlockAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -48,15 +48,30 @@ public class ActionFactory {
 
     /**
      * BlockAction
-     * 
+     *
      * @param action_type
      * @param block
      * @param player
      */
-    public static Handler create(String action_type, Block block, String player) {
+    public static Handler createBlock(String action_type, Block block, String player) {
         final BlockAction a = new BlockAction();
         a.setActionType( action_type );
         a.setBlock( block );
+        a.setPlayerName( player );
+        return a;
+    }
+
+    /**
+     * BlockAction
+     *
+     * @param action_type
+     * @param state
+     * @param player
+     */
+    public static Handler createBlock(String action_type, BlockState state, String player) {
+        final BlockAction a = new BlockAction();
+        a.setActionType( action_type );
+        a.setBlock( state );
         a.setPlayerName( player );
         return a;
     }
@@ -67,8 +82,8 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, Location loc, int oldId, byte oldSubid, int newId, byte newSubid,
-            String player) {
+    public static Handler createBlockChange(String action_type, Location loc, int oldId, byte oldSubid, int newId, byte newSubid,
+                                            String player) {
         final BlockChangeAction a = new BlockChangeAction();
         a.setActionType( action_type );
         a.setBlockId( newId );
@@ -86,7 +101,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, Block from, Location to, String player) {
+    public static Handler createBlockShift(String action_type, Block from, Location to, String player) {
         final BlockShiftAction a = new BlockShiftAction();
         a.setActionType( action_type );
         a.setBlock( from );
@@ -101,11 +116,11 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, Entity entity, String player) {
-        return ActionFactory.create( action_type, entity, player, null );
+    public static Handler createEntity(String action_type, Entity entity, String player) {
+        return ActionFactory.createEntity(action_type, entity, player, null);
     }
 
-    public static Handler create(String action_type, Entity entity, String player, String dyeUsed) {
+    public static Handler createEntity(String action_type, Entity entity, String player, String dyeUsed) {
         final EntityAction a = new EntityAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -118,7 +133,7 @@ public class ActionFactory {
      * 
      * @param action_type
      */
-    public static Handler create(String action_type, Entity entity, Location from, Location to, TeleportCause cause) {
+    public static Handler createEntityTravel(String action_type, Entity entity, Location from, Location to, TeleportCause cause) {
         final EntityTravelAction a = new EntityTravelAction();
         a.setEntity( entity );
         a.setActionType( action_type );
@@ -134,7 +149,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, BlockState blockstate, String player) {
+    public static Handler createGrow(String action_type, BlockState blockstate, String player) {
         final GrowAction a = new GrowAction();
         a.setActionType( action_type );
         a.setBlock( blockstate );
@@ -148,7 +163,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, Hanging hanging, String player) {
+    public static Handler createHangingItem(String action_type, Hanging hanging, String player) {
         final HangingItemAction a = new HangingItemAction();
         a.setActionType( action_type );
         a.setHanging( hanging );
@@ -162,13 +177,13 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, ItemStack item, Map<Enchantment, Integer> enchantments,
-            Location loc, String player) {
-        return ActionFactory.create( action_type, item, 1, -1, enchantments, loc, player );
+    public static Handler createItemStack(String action_type, ItemStack item, Map<Enchantment, Integer> enchantments,
+                                          Location loc, String player) {
+        return ActionFactory.createItemStack(action_type, item, 1, -1, enchantments, loc, player);
     }
 
-    public static Handler create(String action_type, ItemStack item, int quantity, int slot,
-            Map<Enchantment, Integer> enchantments, Location loc, String player) {
+    public static Handler createItemStack(String action_type, ItemStack item, int quantity, int slot,
+                                          Map<Enchantment, Integer> enchantments, Location loc, String player) {
         final ItemStackAction a = new ItemStackAction();
         a.setActionType( action_type );
         a.setLoc( loc );
@@ -183,7 +198,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, Player player, String additionalInfo) {
+    public static Handler createPlayer(String action_type, Player player, String additionalInfo) {
         final PlayerAction a = new PlayerAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -198,7 +213,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, Player player, String cause, String attacker) {
+    public static Handler createPlayerDeath(String action_type, Player player, String cause, String attacker) {
         final PlayerDeathAction a = new PlayerDeathAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -214,7 +229,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, PrismProcessType processType, Player player, String parameters) {
+    public static Handler createPrismProcess(String action_type, PrismProcessType processType, Player player, String parameters) {
         final PrismProcessAction a = new PrismProcessAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -229,8 +244,8 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, BlockState oldblock, BlockState newBlock, String player,
-            int parent_id) {
+    public static Handler createPrismRollback(String action_type, BlockState oldblock, BlockState newBlock, String player,
+                                              int parent_id) {
         final PrismRollbackAction a = new PrismRollbackAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -246,7 +261,7 @@ public class ActionFactory {
      * @param block
      * @param player
      */
-    public static Handler create(String action_type, Block block, String[] lines, String player) {
+    public static Handler createSign(String action_type, Block block, String[] lines, String player) {
         final SignAction a = new SignAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -261,7 +276,7 @@ public class ActionFactory {
      * @param block
      * @param player
      */
-    public static Handler create(String action_type, String item_used, Block block, String player) {
+    public static Handler createUse(String action_type, String item_used, Block block, String player) {
         final UseAction a = new UseAction();
         a.setActionType( action_type );
         a.setPlayerName( player );
@@ -276,7 +291,7 @@ public class ActionFactory {
      * @param action_type
      * @param player
      */
-    public static Handler create(String action_type, Vehicle vehicle, String player) {
+    public static Handler createVehicle(String action_type, Vehicle vehicle, String player) {
         final VehicleAction a = new VehicleAction();
         a.setActionType( action_type );
         a.setPlayerName( player );

--- a/src/main/java/me/botsko/prism/actions/BlockAction.java
+++ b/src/main/java/me/botsko/prism/actions/BlockAction.java
@@ -31,14 +31,22 @@ public class BlockAction extends GenericAction {
     protected BlockActionData actionData;
 
     /**
-     * 
+     *
      * @param block
      */
     public void setBlock(Block block) {
         if( block != null ) {
+            setBlock(block.getState());
+        }
+    }/**
+     *
+     * @param state
+     */
+    public void setBlock(BlockState state) {
+        if( state != null ) {
 
-            block_id = BlockUtils.blockIdMustRecordAs( block.getTypeId() );
-            block_subid = block.getData();
+            block_id = BlockUtils.blockIdMustRecordAs( state.getTypeId() );
+            block_subid = state.getRawData();
 
             // Build an object for the specific details of this action
             // @todo clean this up
@@ -47,18 +55,18 @@ public class BlockAction extends GenericAction {
             }
 
             // spawner
-            if( block.getTypeId() == 52 ) {
+            if( state.getTypeId() == 52 ) {
                 final SpawnerActionData spawnerActionData = new SpawnerActionData();
-                final CreatureSpawner s = (CreatureSpawner) block.getState();
+                final CreatureSpawner s = (CreatureSpawner) state;
                 spawnerActionData.entity_type = s.getSpawnedType().name().toLowerCase();
                 spawnerActionData.delay = s.getDelay();
                 actionData = spawnerActionData;
             }
 
             // skulls
-            else if( ( block.getTypeId() == 144 || block.getTypeId() == 397 ) ) {
+            else if( ( state.getTypeId() == 144 || state.getTypeId() == 397 ) ) {
                 final SkullActionData skullActionData = new SkullActionData();
-                final Skull s = (Skull) block.getState();
+                final Skull s = (Skull) state;
                 skullActionData.rotation = s.getRotation().name().toLowerCase();
                 skullActionData.owner = s.getOwner();
                 skullActionData.skull_type = s.getSkullType().name().toLowerCase();
@@ -66,23 +74,23 @@ public class BlockAction extends GenericAction {
             }
 
             // signs
-            else if( ( block.getTypeId() == 63 || block.getTypeId() == 68 ) ) {
+            else if( ( state.getTypeId() == 63 || state.getTypeId() == 68 ) ) {
                 final SignActionData signActionData = new SignActionData();
-                final Sign s = (Sign) block.getState();
+                final Sign s = (Sign) state;
                 signActionData.lines = s.getLines();
                 actionData = signActionData;
             }
 
             // command block
-            else if( ( block.getTypeId() == 137 ) ) {
-                final CommandBlock cmdblock = (CommandBlock) block.getState();
+            else if( ( state.getTypeId() == 137 ) ) {
+                final CommandBlock cmdblock = (CommandBlock) state;
                 data = cmdblock.getCommand();
             }
 
-            this.world_name = block.getWorld().getName();
-            this.x = block.getLocation().getBlockX();
-            this.y = block.getLocation().getBlockY();
-            this.z = block.getLocation().getBlockZ();
+            this.world_name = state.getWorld().getName();
+            this.x = state.getLocation().getBlockX();
+            this.y = state.getLocation().getBlockY();
+            this.z = state.getLocation().getBlockZ();
         }
     }
 

--- a/src/main/java/me/botsko/prism/actions/GrowAction.java
+++ b/src/main/java/me/botsko/prism/actions/GrowAction.java
@@ -6,16 +6,16 @@ public class GrowAction extends BlockAction {
 
     /**
      * 
-     * @param blockstate
+     * @param state
      */
-    public void setBlock(BlockState blockstate) {
-        if( blockstate != null ) {
-            this.block_id = blockstate.getTypeId();
-            this.block_subid = blockstate.getData().getData();
-            this.world_name = blockstate.getWorld().getName();
-            this.x = blockstate.getLocation().getBlockX();
-            this.y = blockstate.getLocation().getBlockY();
-            this.z = blockstate.getLocation().getBlockZ();
+    public void setBlock(BlockState state) {
+        if( state != null ) {
+            this.block_id = state.getTypeId();
+            this.block_subid = state.getData().getData();
+            this.world_name = state.getWorld().getName();
+            this.x = state.getLocation().getBlockX();
+            this.y = state.getLocation().getBlockY();
+            this.z = state.getLocation().getBlockZ();
         }
     }
 }

--- a/src/main/java/me/botsko/prism/bridge/PrismBlockEditSession.java
+++ b/src/main/java/me/botsko/prism/bridge/PrismBlockEditSession.java
@@ -60,8 +60,8 @@ public class PrismBlockEditSession extends EditSession {
         if( success ) {
             final Location loc = new Location( Bukkit.getWorld( player.getWorld().getName() ), pt.getBlockX(),
                     pt.getBlockY(), pt.getBlockZ() );
-            RecordingQueue.addToQueue( ActionFactory.create( "world-edit", loc, typeBefore, dataBefore, loc.getBlock()
-                    .getTypeId(), loc.getBlock().getData(), player.getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createBlockChange("world-edit", loc, typeBefore, dataBefore, loc.getBlock()
+                    .getTypeId(), loc.getBlock().getData(), player.getName()) );
         }
         return success;
     }

--- a/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
@@ -6,7 +6,6 @@ import java.util.List;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionFactory;
 import me.botsko.prism.actionlibs.RecordingQueue;
-import me.botsko.prism.utils.BlockUtils;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -66,8 +65,8 @@ public class PrismBlockEvents implements Listener {
             if( playing == null || playing.equals( Material.AIR ) )
                 return;
             final ItemStack i = new ItemStack( jukebox.getPlaying(), 1 );
-            RecordingQueue.addToQueue( ActionFactory.create( "item-remove", i, i.getAmount(), 0, null,
-                    block.getLocation(), player_name ) );
+            RecordingQueue.addToQueue( ActionFactory.createItemStack("item-remove", i, i.getAmount(), 0, null,
+                    block.getLocation(), player_name) );
             return;
         }
         if( block.getState() instanceof InventoryHolder ) {
@@ -81,8 +80,8 @@ public class PrismBlockEvents implements Listener {
                     break;
                 // record item
                 if( i != null ) {
-                    RecordingQueue.addToQueue( ActionFactory.create( "item-remove", i, i.getAmount(), slot, null,
-                            block.getLocation(), player_name ) );
+                    RecordingQueue.addToQueue( ActionFactory.createItemStack("item-remove", i, i.getAmount(), slot, null,
+                            block.getLocation(), player_name) );
                 }
                 slot++;
             }
@@ -119,7 +118,7 @@ public class PrismBlockEvents implements Listener {
             final ArrayList<Block> pistonBases = me.botsko.elixr.BlockUtils.findSideFaceAttachedBlocks( block );
             if( pistonBases.size() > 0 ) {
                 for ( final Block p : pistonBases ) {
-                    RecordingQueue.addToQueue( ActionFactory.create( "block-break", p, playername ) );
+                    RecordingQueue.addToQueue( ActionFactory.createBlock("block-break", p, playername) );
                 }
             }
         }
@@ -190,7 +189,7 @@ public class PrismBlockEvents implements Listener {
         // properly
         logItemRemoveFromDestroyedContainer( player.getName(), block );
 
-        RecordingQueue.addToQueue( ActionFactory.create( "block-break", block, player.getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlock("block-break", block, player.getName()) );
 
         // check for block relationships
         logBlockRelationshipsForBlock( player.getName(), block );
@@ -201,7 +200,7 @@ public class PrismBlockEvents implements Listener {
                     block, null );
             if( !blocks.isEmpty() ) {
                 // Only log 1 portal break, we don't need all 8
-                RecordingQueue.addToQueue( ActionFactory.create( "block-break", blocks.get( 0 ), player.getName() ) );
+                RecordingQueue.addToQueue( ActionFactory.createBlock("block-break", blocks.get(0), player.getName()) );
             }
         }
 
@@ -228,8 +227,8 @@ public class PrismBlockEvents implements Listener {
             return;
 
         final BlockState s = event.getBlockReplacedState();
-        RecordingQueue.addToQueue( ActionFactory.create( "block-place", block.getLocation(), s.getTypeId(),
-                s.getRawData(), block.getTypeId(), block.getData(), player.getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlockChange("block-place", block.getLocation(), s.getTypeId(),
+                s.getRawData(), block.getTypeId(), block.getData(), player.getName()) );
 
         // Pass to the placement alerter
         if( !player.hasPermission( "prism.alerts.use.place.ignore" ) && !player.hasPermission( "prism.alerts.ignore" ) ) {
@@ -257,8 +256,8 @@ public class PrismBlockEvents implements Listener {
 
         final Block b = event.getBlock();
         final BlockState s = event.getNewState();
-        RecordingQueue.addToQueue( ActionFactory.create( type, b.getLocation(), b.getTypeId(), b.getData(),
-                s.getTypeId(), s.getRawData(), "Environment" ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlockChange(type, b.getLocation(), b.getTypeId(), b.getData(),
+                s.getTypeId(), s.getRawData(), "Environment") );
     }
 
     /**
@@ -271,8 +270,8 @@ public class PrismBlockEvents implements Listener {
             return;
         final Block b = event.getBlock();
         final BlockState s = event.getNewState();
-        RecordingQueue.addToQueue( ActionFactory.create( "block-form", b.getLocation(), b.getTypeId(), b.getData(),
-                s.getTypeId(), s.getRawData(), "Environment" ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlockChange("block-form", b.getLocation(), b.getTypeId(), b.getData(),
+                s.getTypeId(), s.getRawData(), "Environment") );
     }
 
     /**
@@ -287,8 +286,8 @@ public class PrismBlockEvents implements Listener {
         if( b.getType().equals( Material.FIRE ) )
             return;
         final BlockState s = event.getNewState();
-        RecordingQueue.addToQueue( ActionFactory.create( "block-fade", b.getLocation(), b.getTypeId(), b.getData(),
-                s.getTypeId(), s.getRawData(), "Environment" ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlockChange("block-fade", b.getLocation(), b.getTypeId(), b.getData(),
+                s.getTypeId(), s.getRawData(), "Environment") );
     }
 
     /**
@@ -299,7 +298,7 @@ public class PrismBlockEvents implements Listener {
     public void onLeavesDecay(final LeavesDecayEvent event) {
         if( !Prism.getIgnore().event( "leaf-decay", event.getBlock() ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "leaf-decay", event.getBlock(), "Environment" ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlock("leaf-decay", event.getBlock(), "Environment") );
     }
 
     /**
@@ -311,7 +310,7 @@ public class PrismBlockEvents implements Listener {
         if( !Prism.getIgnore().event( "block-burn", event.getBlock() ) )
             return;
         Block block = event.getBlock();
-        RecordingQueue.addToQueue( ActionFactory.create( "block-burn", block, "Environment" ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlock("block-burn", block, "Environment") );
 
         // Change handling a bit if it's a long block
         final Block sibling = me.botsko.elixr.BlockUtils.getSiblingForDoubleLengthBlock( block );
@@ -334,8 +333,8 @@ public class PrismBlockEvents implements Listener {
         if( !Prism.getIgnore().event( "sign-change", event.getPlayer() ) )
             return;
         if( event.getBlock().getState().getData() instanceof Sign ) {
-            RecordingQueue.addToQueue( ActionFactory.create( "sign-change", event.getBlock(), event.getLines(), event
-                    .getPlayer().getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createSign("sign-change", event.getBlock(), event.getLines(), event
+                    .getPlayer().getName()) );
         }
     }
 
@@ -377,8 +376,8 @@ public class PrismBlockEvents implements Listener {
                 }
             }
 
-            RecordingQueue.addToQueue( ActionFactory.create( cause, event.getBlock(), ( player == null ? "Environment"
-                    : player.getName() ) ) );
+            RecordingQueue.addToQueue( ActionFactory.createBlock(cause, event.getBlock(), (player == null ? "Environment"
+                    : player.getName())) );
 
         }
     }
@@ -391,8 +390,8 @@ public class PrismBlockEvents implements Listener {
     public void onBlockDispense(final BlockDispenseEvent event) {
         if( !Prism.getIgnore().event( "block-dispense" ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "block-dispense", event.getItem(),
-                event.getItem().getAmount(), -1, null, event.getBlock().getLocation(), "dispenser" ) );
+        RecordingQueue.addToQueue( ActionFactory.createItemStack("block-dispense", event.getItem(),
+                event.getItem().getAmount(), -1, null, event.getBlock().getLocation(), "dispenser") );
     }
 
     /**
@@ -429,8 +428,8 @@ public class PrismBlockEvents implements Listener {
                 // there it shows as air.
                 // We should record the from coords, to coords, and block
                 // replaced, as well as the block moved.
-                RecordingQueue.addToQueue( ActionFactory.create( "block-shift", block,
-                        block.getRelative( event.getDirection() ).getLocation(), "Piston" ) );
+                RecordingQueue.addToQueue( ActionFactory.createBlockShift("block-shift", block,
+                        block.getRelative(event.getDirection()).getLocation(), "Piston") );
 
             }
         }
@@ -449,8 +448,8 @@ public class PrismBlockEvents implements Listener {
         final Block block = event.getBlock();
         if( block.getType().equals( Material.AIR ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "block-shift", event.getRetractLocation().getBlock(), block
-                .getRelative( event.getDirection() ).getLocation(), "Piston" ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlockShift("block-shift", event.getRetractLocation().getBlock(), block
+                .getRelative(event.getDirection()).getLocation(), "Piston") );
     }
 
     /**
@@ -471,11 +470,11 @@ public class PrismBlockEvents implements Listener {
         if( me.botsko.elixr.BlockUtils.canFlowBreakMaterial( to.getType() ) ) {
             if( from.getType() == Material.STATIONARY_WATER || from.getType() == Material.WATER ) {
                 if( Prism.getIgnore().event( "water-break", event.getBlock() ) ) {
-                    RecordingQueue.addToQueue( ActionFactory.create( "water-break", event.getToBlock(), "Water" ) );
+                    RecordingQueue.addToQueue( ActionFactory.createBlock("water-break", event.getToBlock(), "Water") );
                 }
             } else if( from.getType() == Material.STATIONARY_LAVA || from.getType() == Material.LAVA ) {
                 if( Prism.getIgnore().event( "lava-break", event.getBlock() ) ) {
-                    RecordingQueue.addToQueue( ActionFactory.create( "lava-break", event.getToBlock(), "Lava" ) );
+                    RecordingQueue.addToQueue( ActionFactory.createBlock("lava-break", event.getToBlock(), "Lava") );
                 }
             }
         }
@@ -483,14 +482,14 @@ public class PrismBlockEvents implements Listener {
         // Record water flow
         if( from.getType() == Material.STATIONARY_WATER || from.getType() == Material.WATER ) {
             if( Prism.getIgnore().event( "water-flow", event.getBlock() ) ) {
-                RecordingQueue.addToQueue( ActionFactory.create( "water-flow", event.getBlock(), "Water" ) );
+                RecordingQueue.addToQueue( ActionFactory.createBlock("water-flow", event.getBlock(), "Water") );
             }
         }
 
         // Record lava flow
         if( from.getType() == Material.STATIONARY_LAVA || from.getType() == Material.LAVA ) {
             if( Prism.getIgnore().event( "lava-flow", event.getBlock() ) ) {
-                RecordingQueue.addToQueue( ActionFactory.create( "lava-flow", event.getBlock(), "Lava" ) );
+                RecordingQueue.addToQueue( ActionFactory.createBlock("lava-flow", event.getBlock(), "Lava") );
             }
         }
 
@@ -506,7 +505,7 @@ public class PrismBlockEvents implements Listener {
         if( from.getType().equals( Material.STATIONARY_LAVA ) && to.getType().equals( Material.STATIONARY_WATER ) ) {
             final Block newTo = event.getToBlock();
             newTo.setType( Material.STONE );
-            RecordingQueue.addToQueue( ActionFactory.create( "block-form", newTo, "Environment" ) );
+            RecordingQueue.addToQueue( ActionFactory.createBlock("block-form", newTo, "Environment") );
         }
 
         // // int id = event.getBlock().getTypeId();

--- a/src/main/java/me/botsko/prism/listeners/PrismBlockPhysicsEvent.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismBlockPhysicsEvent.java
@@ -3,7 +3,6 @@ package me.botsko.prism.listeners;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionFactory;
 import me.botsko.prism.actionlibs.RecordingQueue;
-import me.botsko.prism.utils.BlockUtils;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -47,7 +46,7 @@ public class PrismBlockPhysicsEvent implements Listener {
                 final String coord_key = b.getX() + ":" + b.getY() + ":" + b.getZ();
                 if( plugin.preplannedBlockFalls.containsKey( coord_key ) ) {
                     final String player = plugin.preplannedBlockFalls.get( coord_key );
-                    RecordingQueue.addToQueue( ActionFactory.create( "block-fall", b, player ) );
+                    RecordingQueue.addToQueue( ActionFactory.createBlock("block-fall", b, player) );
                     plugin.preplannedBlockFalls.remove( coord_key );
                 }
             }
@@ -72,7 +71,7 @@ public class PrismBlockPhysicsEvent implements Listener {
                     final String coord_key = b.getX() + ":" + b.getY() + ":" + b.getZ();
                     if( plugin.preplannedBlockFalls.containsKey( coord_key ) ) {
                         final String player = plugin.preplannedBlockFalls.get( coord_key );
-                        RecordingQueue.addToQueue( ActionFactory.create( "block-break", b, player ) );
+                        RecordingQueue.addToQueue( ActionFactory.createBlock("block-break", b, player) );
                         plugin.preplannedBlockFalls.remove( coord_key );
                     }
                 }
@@ -87,7 +86,7 @@ public class PrismBlockPhysicsEvent implements Listener {
                 final String coord_key = b.getX() + ":" + b.getY() + ":" + b.getZ();
                 if( plugin.preplannedBlockFalls.containsKey( coord_key ) ) {
                     final String player = plugin.preplannedBlockFalls.get( coord_key );
-                    RecordingQueue.addToQueue( ActionFactory.create( "block-break", b, player ) );
+                    RecordingQueue.addToQueue( ActionFactory.createBlock("block-break", b, player) );
                     plugin.preplannedBlockFalls.remove( coord_key );
                 }
             }

--- a/src/main/java/me/botsko/prism/listeners/PrismChannelChatEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismChannelChatEvents.java
@@ -21,6 +21,6 @@ public class PrismChannelChatEvents implements Listener {
         if( !Prism.getIgnore().event( "player-chat", event.getSender().getPlayer() ) )
             return;
         final String msg = "[" + event.getChannel().getNick().toLowerCase() + "] " + event.getMessage();
-        RecordingQueue.addToQueue( ActionFactory.create( "player-chat", event.getSender().getPlayer(), msg ) );
+        RecordingQueue.addToQueue( ActionFactory.createPlayer("player-chat", event.getSender().getPlayer(), msg) );
     }
 }

--- a/src/main/java/me/botsko/prism/listeners/PrismCustomEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismCustomEvents.java
@@ -36,8 +36,8 @@ public class PrismCustomEvents implements Listener {
         final ArrayList<String> allowedPlugins = (ArrayList<String>) plugin.getConfig().getList(
                 "prism.tracking.api.allowed-plugins" );
         if( allowedPlugins.contains( event.getPluginName() ) ) {
-            RecordingQueue.addToQueue( ActionFactory.create( event.getActionTypeName(), event.getPlayer(),
-                    event.getMessage() ) );
+            RecordingQueue.addToQueue( ActionFactory.createPlayer(event.getActionTypeName(), event.getPlayer(),
+                    event.getMessage()) );
         }
     }
 }

--- a/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
@@ -6,7 +6,6 @@ import me.botsko.elixr.DeathUtils;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionFactory;
 import me.botsko.prism.actionlibs.RecordingQueue;
-import me.botsko.prism.utils.BlockUtils;
 import me.botsko.prism.utils.MiscUtils;
 import me.botsko.prism.utils.WandUtils;
 
@@ -92,8 +91,8 @@ public class PrismEntityEvents implements Listener {
             // Frame is empty but an item is held
             if( !frame.getItem().getType().equals( Material.AIR ) ) {
                 if( Prism.getIgnore().event( "item-remove", player ) ) {
-                    RecordingQueue.addToQueue( ActionFactory.create( "item-remove", frame.getItem(), 1, 0, null,
-                            entity.getLocation(), player.getName() ) );
+                    RecordingQueue.addToQueue( ActionFactory.createItemStack("item-remove", frame.getItem(), 1, 0, null,
+                            entity.getLocation(), player.getName()) );
                 }
             }
         }
@@ -120,8 +119,8 @@ public class PrismEntityEvents implements Listener {
                             for ( final ItemStack i : horse.getInventory().getContents() ) {
                                 if( i == null )
                                     continue;
-                                RecordingQueue.addToQueue( ActionFactory.create( "item-drop", i, i.getAmount(), -1,
-                                        null, entity.getLocation(), "horse" ) );
+                                RecordingQueue.addToQueue( ActionFactory.createItemStack("item-drop", i, i.getAmount(), -1,
+                                        null, entity.getLocation(), "horse") );
                             }
                         }
                     }
@@ -134,7 +133,7 @@ public class PrismEntityEvents implements Listener {
                     final Player player = (Player) entityDamageByEntityEvent.getDamager();
                     if( !Prism.getIgnore().event( "player-kill", player ) )
                         return;
-                    RecordingQueue.addToQueue( ActionFactory.create( "player-kill", entity, player.getName() ) );
+                    RecordingQueue.addToQueue( ActionFactory.createEntity("player-kill", entity, player.getName()) );
 
                 }
                 // Mob shot by an arrow from a player
@@ -145,7 +144,7 @@ public class PrismEntityEvents implements Listener {
                         final Player player = (Player) arrow.getShooter();
                         if( !Prism.getIgnore().event( "player-kill", player ) )
                             return;
-                        RecordingQueue.addToQueue( ActionFactory.create( "player-kill", entity, player.getName() ) );
+                        RecordingQueue.addToQueue( ActionFactory.createEntity("player-kill", entity, player.getName()) );
 
                     }
                 } else {
@@ -159,7 +158,7 @@ public class PrismEntityEvents implements Listener {
                         name = "unknown";
                     if( !Prism.getIgnore().event( "entity-kill", entity.getWorld() ) )
                         return;
-                    RecordingQueue.addToQueue( ActionFactory.create( "entity-kill", entity, name ) );
+                    RecordingQueue.addToQueue( ActionFactory.createEntity("entity-kill", entity, name) );
                 }
             } else {
 
@@ -176,7 +175,7 @@ public class PrismEntityEvents implements Listener {
                 }
 
                 // Record the death as natural
-                RecordingQueue.addToQueue( ActionFactory.create( "entity-kill", entity, killer ) );
+                RecordingQueue.addToQueue( ActionFactory.createEntity("entity-kill", entity, killer) );
 
             }
         } else {
@@ -190,15 +189,15 @@ public class PrismEntityEvents implements Listener {
                     final String owner = DeathUtils.getTameWolfOwner( event );
                     attacker = owner + "'s wolf";
                 }
-                RecordingQueue.addToQueue( ActionFactory.create( "player-death", p, cause, attacker ) );
+                RecordingQueue.addToQueue( ActionFactory.createPlayerDeath("player-death", p, cause, attacker) );
             }
 
             // Log item drops
             if( Prism.getIgnore().event( "item-drop", p ) ) {
                 if( !event.getDrops().isEmpty() ) {
                     for ( final ItemStack i : event.getDrops() ) {
-                        RecordingQueue.addToQueue( ActionFactory.create( "item-drop", i, i.getAmount(), -1, null,
-                                p.getLocation(), p.getName() ) );
+                        RecordingQueue.addToQueue( ActionFactory.createItemStack("item-drop", i, i.getAmount(), -1, null,
+                                p.getLocation(), p.getName()) );
                     }
                 }
             }
@@ -216,7 +215,7 @@ public class PrismEntityEvents implements Listener {
         final String reason = event.getSpawnReason().name().toLowerCase().replace( "_", " " );
         if( reason.equals( "natural" ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "entity-spawn", event.getEntity(), reason ) );
+        RecordingQueue.addToQueue( ActionFactory.createEntity("entity-spawn", event.getEntity(), reason) );
     }
 
     /**
@@ -231,7 +230,7 @@ public class PrismEntityEvents implements Listener {
             if( event.getEntity().getType().equals( EntityType.CREEPER ) ) {
                 final Player player = (Player) event.getTarget();
                 RecordingQueue
-                        .addToQueue( ActionFactory.create( "entity-follow", event.getEntity(), player.getName() ) );
+                        .addToQueue( ActionFactory.createEntity("entity-follow", event.getEntity(), player.getName()) );
             }
         }
     }
@@ -245,7 +244,7 @@ public class PrismEntityEvents implements Listener {
         if( !Prism.getIgnore().event( "entity-shear", event.getPlayer() ) )
             return;
         RecordingQueue
-                .addToQueue( ActionFactory.create( "entity-shear", event.getEntity(), event.getPlayer().getName() ) );
+                .addToQueue( ActionFactory.createEntity("entity-shear", event.getEntity(), event.getPlayer().getName()) );
     }
 
     /**
@@ -271,15 +270,15 @@ public class PrismEntityEvents implements Listener {
 
             // If held item doesn't equal existing item frame object type
             if( !frame.getItem().getType().equals( Material.AIR ) ) {
-                RecordingQueue.addToQueue( ActionFactory.create( "item-rotate", event.getPlayer(), frame.getRotation()
-                        .name().toLowerCase() ) );
+                RecordingQueue.addToQueue( ActionFactory.createPlayer("item-rotate", event.getPlayer(), frame.getRotation()
+                        .name().toLowerCase()) );
             }
 
             // Frame is empty but an item is held
             if( frame.getItem().getType().equals( Material.AIR ) && p.getItemInHand() != null ) {
                 if( Prism.getIgnore().event( "item-insert", p ) ) {
-                    RecordingQueue.addToQueue( ActionFactory.create( "item-insert", p.getItemInHand(), 1, 0, null,
-                            e.getLocation(), p.getName() ) );
+                    RecordingQueue.addToQueue( ActionFactory.createItemStack("item-insert", p.getItemInHand(), 1, 0, null,
+                            e.getLocation(), p.getName()) );
                 }
             }
         }
@@ -289,8 +288,8 @@ public class PrismEntityEvents implements Listener {
         if( p.getItemInHand().getType().equals( Material.COAL ) && e instanceof PoweredMinecart ) {
             if( !Prism.getIgnore().event( "item-insert", p ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "item-insert", p.getItemInHand(), 1, 0, null,
-                    e.getLocation(), p.getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createItemStack("item-insert", p.getItemInHand(), 1, 0, null,
+                    e.getLocation(), p.getName()) );
         }
 
         if( !Prism.getIgnore().event( "entity-dye", p ) )
@@ -299,8 +298,8 @@ public class PrismEntityEvents implements Listener {
         if( p.getItemInHand().getTypeId() == 351 && e.getType().equals( EntityType.SHEEP ) ) {
             final String newColor = Prism.getItems().getAlias( p.getItemInHand().getTypeId(),
                     (byte) p.getItemInHand().getDurability() );
-            RecordingQueue.addToQueue( ActionFactory.create( "entity-dye", event.getRightClicked(), event.getPlayer()
-                    .getName(), newColor ) );
+            RecordingQueue.addToQueue( ActionFactory.createEntity("entity-dye", event.getRightClicked(), event.getPlayer()
+                    .getName(), newColor) );
         }
     }
 
@@ -312,8 +311,8 @@ public class PrismEntityEvents implements Listener {
     public void onEntityBreakDoor(final EntityBreakDoorEvent event) {
         if( !Prism.getIgnore().event( "entity-break", event.getEntity().getWorld() ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "entity-break", event.getBlock(), event.getEntityType()
-                .getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlock("entity-break", event.getBlock(), event.getEntityType()
+                .getName()) );
     }
 
     /**
@@ -325,7 +324,7 @@ public class PrismEntityEvents implements Listener {
         if( !Prism.getIgnore().event( "entity-leash", event.getPlayer() ) )
             return;
         RecordingQueue
-                .addToQueue( ActionFactory.create( "entity-leash", event.getEntity(), event.getPlayer().getName() ) );
+                .addToQueue( ActionFactory.createEntity("entity-leash", event.getEntity(), event.getPlayer().getName()) );
     }
 
     /**
@@ -336,8 +335,8 @@ public class PrismEntityEvents implements Listener {
     public void onPlayerEntityUnleash(final PlayerUnleashEntityEvent event) {
         if( !Prism.getIgnore().event( "entity-unleash", event.getPlayer() ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "entity-unleash", event.getEntity(), event.getPlayer()
-                .getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createEntity("entity-unleash", event.getEntity(), event.getPlayer()
+                .getName()) );
     }
 
     /**
@@ -348,8 +347,8 @@ public class PrismEntityEvents implements Listener {
     public void onEntityUnleash(final EntityUnleashEvent event) {
         if( !Prism.getIgnore().event( "entity-unleash" ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "entity-unleash", event.getEntity(), event.getReason()
-                .toString().toLowerCase() ) );
+        RecordingQueue.addToQueue( ActionFactory.createEntity("entity-unleash", event.getEntity(), event.getReason()
+                .toString().toLowerCase()) );
     }
 
     /**
@@ -378,7 +377,7 @@ public class PrismEntityEvents implements Listener {
             name = eff.getType().getName().toLowerCase();
         }
 
-        RecordingQueue.addToQueue( ActionFactory.create( "potion-splash", player, name ) );
+        RecordingQueue.addToQueue( ActionFactory.createPlayer("potion-splash", player, name) );
 
     }
 
@@ -395,8 +394,8 @@ public class PrismEntityEvents implements Listener {
         }
         if( !Prism.getIgnore().event( "hangingitem-place", event.getPlayer() ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "hangingitem-place", event.getEntity(), event.getPlayer()
-                .getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createHangingItem("hangingitem-place", event.getEntity(), event.getPlayer()
+                .getName()) );
     }
 
     /**
@@ -425,7 +424,7 @@ public class PrismEntityEvents implements Listener {
             final String player = plugin.preplannedBlockFalls.get( coord_key );
 
             // Track the hanging item break
-            RecordingQueue.addToQueue( ActionFactory.create( "hangingitem-break", e, player ) );
+            RecordingQueue.addToQueue( ActionFactory.createHangingItem("hangingitem-break", e, player) );
             plugin.preplannedBlockFalls.remove( coord_key );
 
             if( !Prism.getIgnore().event( "item-remove", event.getEntity().getWorld() ) )
@@ -435,8 +434,8 @@ public class PrismEntityEvents implements Listener {
             if( e instanceof ItemFrame ) {
                 final ItemFrame frame = (ItemFrame) e;
                 if( frame.getItem() != null ) {
-                    RecordingQueue.addToQueue( ActionFactory.create( "item-remove", frame.getItem(), frame.getItem()
-                            .getAmount(), -1, null, e.getLocation(), player ) );
+                    RecordingQueue.addToQueue( ActionFactory.createItemStack("item-remove", frame.getItem(), frame.getItem()
+                            .getAmount(), -1, null, e.getLocation(), player) );
                 }
             }
         }
@@ -468,7 +467,7 @@ public class PrismEntityEvents implements Listener {
         if( player != null )
             breaking_name = player.getName();
 
-        RecordingQueue.addToQueue( ActionFactory.create( "hangingitem-break", event.getEntity(), breaking_name ) );
+        RecordingQueue.addToQueue( ActionFactory.createHangingItem("hangingitem-break", event.getEntity(), breaking_name) );
 
         if( !Prism.getIgnore().event( "item-remove", event.getEntity().getWorld() ) )
             return;
@@ -477,8 +476,8 @@ public class PrismEntityEvents implements Listener {
         if( event.getEntity() instanceof ItemFrame ) {
             final ItemFrame frame = (ItemFrame) event.getEntity();
             if( frame.getItem() != null ) {
-                RecordingQueue.addToQueue( ActionFactory.create( "item-remove", frame.getItem(), frame.getItem()
-                        .getAmount(), -1, null, entity.getLocation(), breaking_name ) );
+                RecordingQueue.addToQueue( ActionFactory.createItemStack("item-remove", frame.getItem(), frame.getItem()
+                        .getAmount(), -1, null, entity.getLocation(), breaking_name) );
             }
         }
     }
@@ -501,18 +500,22 @@ public class PrismEntityEvents implements Listener {
                 return;
             if( !Prism.getIgnore().event( "sheep-eat", event.getBlock() ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "sheep-eat", event.getBlock(), entity ) );
+            RecordingQueue.addToQueue( ActionFactory.createBlock("sheep-eat", event.getBlock(), entity) );
         } else if (to == Material.AIR ^ from == Material.AIR && event.getEntity() instanceof Enderman) {
-            if (to == Material.AIR) {
+            if (from == Material.AIR) {
                 if (!Prism.getIgnore().event("enderman-place", event.getBlock()))
                     return;
-                RecordingQueue.addToQueue(ActionFactory.create("enderman-place", event.getBlock(), entity));
+                BlockState state = event.getBlock().getState();
+                state.setType(to);
+                RecordingQueue.addToQueue(ActionFactory.createBlock("enderman-place", state, entity));
             } else {
                 if (!Prism.getIgnore().event("enderman-pickup", event.getBlock()))
                     return;
                 final Enderman enderman = (Enderman) event.getEntity();
                 if (enderman.getCarriedMaterial() != null) {
-                    RecordingQueue.addToQueue(ActionFactory.create("enderman-pickup", event.getBlock(), entity));
+                    BlockState state = event.getBlock().getState();
+                    state.setData(enderman.getCarriedMaterial());
+                    RecordingQueue.addToQueue(ActionFactory.createBlock("enderman-pickup", state, entity));
                 }
             }
         }
@@ -530,8 +533,8 @@ public class PrismEntityEvents implements Listener {
         final Location loc = block.getLocation();
         final BlockState newState = event.getNewState();
         final String entity = event.getEntity().getType().name().toLowerCase();
-        RecordingQueue.addToQueue( ActionFactory.create( "entity-form", loc, block.getTypeId(), block.getData(),
-                newState.getTypeId(), newState.getRawData(), entity ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlockChange("entity-form", loc, block.getTypeId(), block.getData(),
+                newState.getTypeId(), newState.getRawData(), entity) );
     }
 
     /**
@@ -617,7 +620,7 @@ public class PrismEntityEvents implements Listener {
             // note: done before the container so a "rewind" for rollback will
             // work properly
             be.logItemRemoveFromDestroyedContainer( name, block );
-            RecordingQueue.addToQueue( ActionFactory.create( action, block, name ) );
+            RecordingQueue.addToQueue( ActionFactory.createBlock(action, block, name) );
             // look for relationships
             be.logBlockRelationshipsForBlock( name, block );
 

--- a/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
@@ -7,6 +7,7 @@ import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionFactory;
 import me.botsko.prism.actionlibs.RecordingQueue;
 import me.botsko.prism.utils.BlockUtils;
+import me.botsko.prism.utils.MiscUtils;
 import me.botsko.prism.utils.WandUtils;
 
 import org.bukkit.Location;
@@ -488,33 +489,28 @@ public class PrismEntityEvents implements Listener {
      */
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onEntityChangeBlock(final EntityChangeBlockEvent event) {
-    	
-    	if( event.getEntityType() == null || event.getEntityType().getName() == null ) return;
-    	
-        final String entity = event.getEntityType().getName().toLowerCase();
+        final String entity = MiscUtils.getEntityName(event.getEntity());
 
         // Technically I think that I really should name it "entity-eat" for
         // better consistency and
         // in case other mobs ever are made to eat. But that's not as fun
-        if( event.getEntityType().equals( EntityType.SHEEP ) ) {
+        if( event.getBlock().getType() == Material.GRASS && event.getTo() == Material.DIRT) {
+            if( event.getEntityType() != EntityType.SHEEP )
+                return;
             if( !Prism.getIgnore().event( "sheep-eat", event.getBlock() ) )
                 return;
             RecordingQueue.addToQueue( ActionFactory.create( "sheep-eat", event.getBlock(), entity ) );
-        } else {
-
-            if( event.getEntity() instanceof Enderman ) {
-
-                if( event.getTo() == Material.AIR ) {
-                    if( !Prism.getIgnore().event( "enderman-place", event.getBlock() ) )
-                        return;
-                    RecordingQueue.addToQueue( ActionFactory.create( "enderman-place", event.getBlock(), entity ) );
-                } else {
-                    if( !Prism.getIgnore().event( "enderman-pickup", event.getBlock() ) )
-                        return;
-                    final Enderman enderman = (Enderman) event.getEntity();
-                    if( enderman.getCarriedMaterial() != null ) {
-                        RecordingQueue.addToQueue( ActionFactory.create( "enderman-pickup", event.getBlock(), entity ) );
-                    }
+        } else if (event.getEntity() instanceof Enderman) {
+            if (event.getTo() == Material.AIR) {
+                if (!Prism.getIgnore().event("enderman-place", event.getBlock()))
+                    return;
+                RecordingQueue.addToQueue(ActionFactory.create("enderman-place", event.getBlock(), entity));
+            } else {
+                if (!Prism.getIgnore().event("enderman-pickup", event.getBlock()))
+                    return;
+                final Enderman enderman = (Enderman) event.getEntity();
+                if (enderman.getCarriedMaterial() != null) {
+                    RecordingQueue.addToQueue(ActionFactory.create("enderman-pickup", event.getBlock(), entity));
                 }
             }
         }

--- a/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismEntityEvents.java
@@ -494,14 +494,16 @@ public class PrismEntityEvents implements Listener {
         // Technically I think that I really should name it "entity-eat" for
         // better consistency and
         // in case other mobs ever are made to eat. But that's not as fun
-        if( event.getBlock().getType() == Material.GRASS && event.getTo() == Material.DIRT) {
+        Material to = event.getTo();
+        Material from = event.getBlock().getType();
+        if( from == Material.GRASS && to == Material.DIRT) {
             if( event.getEntityType() != EntityType.SHEEP )
                 return;
             if( !Prism.getIgnore().event( "sheep-eat", event.getBlock() ) )
                 return;
             RecordingQueue.addToQueue( ActionFactory.create( "sheep-eat", event.getBlock(), entity ) );
-        } else if (event.getEntity() instanceof Enderman) {
-            if (event.getTo() == Material.AIR) {
+        } else if (to == Material.AIR ^ from == Material.AIR && event.getEntity() instanceof Enderman) {
+            if (to == Material.AIR) {
                 if (!Prism.getIgnore().event("enderman-place", event.getBlock()))
                     return;
                 RecordingQueue.addToQueue(ActionFactory.create("enderman-place", event.getBlock(), entity));

--- a/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
@@ -53,8 +53,8 @@ public class PrismInventoryEvents implements Listener {
 
         // If hopper
         if( event.getInventory().getType().equals( InventoryType.HOPPER ) ) {
-            RecordingQueue.addToQueue( ActionFactory.create( "item-pickup", event.getItem().getItemStack(), event
-                    .getItem().getItemStack().getAmount(), -1, null, event.getItem().getLocation(), "hopper" ) );
+            RecordingQueue.addToQueue( ActionFactory.createItemStack("item-pickup", event.getItem().getItemStack(), event
+                    .getItem().getItemStack().getAmount(), -1, null, event.getItem().getLocation(), "hopper") );
         }
     }
 
@@ -196,8 +196,8 @@ public class PrismInventoryEvents implements Listener {
 
         // Record it!
         if( actionType != null && containerLoc != null && item != null && item.getTypeId() != 0 && officialQuantity > 0 ) {
-            RecordingQueue.addToQueue( ActionFactory.create( actionType, item, officialQuantity, slot, null,
-                    containerLoc, player.getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createItemStack(actionType, item, officialQuantity, slot, null,
+                    containerLoc, player.getName()) );
         }
     }
 }

--- a/src/main/java/me/botsko/prism/listeners/PrismInventoryMoveItemEvent.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismInventoryMoveItemEvent.java
@@ -40,8 +40,8 @@ public class PrismInventoryMoveItemEvent implements Listener {
             return;
 
         if( event.getSource().getType().equals( InventoryType.HOPPER ) ) {
-            RecordingQueue.addToQueue( ActionFactory.create( "item-insert", event.getItem(), event.getItem()
-                    .getAmount(), 0, null, containerLoc, "hopper" ) );
+            RecordingQueue.addToQueue( ActionFactory.createItemStack("item-insert", event.getItem(), event.getItem()
+                    .getAmount(), 0, null, containerLoc, "hopper") );
         }
     }
 }

--- a/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
@@ -106,7 +106,7 @@ public class PrismPlayerEvents implements Listener {
         // Ignore some commands based on config
         if( ignoreCommands.contains( primaryCmd ) ) { return; }
 
-        RecordingQueue.addToQueue( ActionFactory.create( "player-command", player, event.getMessage() ) );
+        RecordingQueue.addToQueue( ActionFactory.createPlayer("player-command", player, event.getMessage()) );
 
     }
 
@@ -131,7 +131,7 @@ public class PrismPlayerEvents implements Listener {
             ip = player.getAddress().getAddress().getHostAddress().toString();
         }
 
-        RecordingQueue.addToQueue( ActionFactory.create( "player-join", event.getPlayer(), ip ) );
+        RecordingQueue.addToQueue( ActionFactory.createPlayer("player-join", event.getPlayer(), ip) );
     }
 
     /**
@@ -148,7 +148,7 @@ public class PrismPlayerEvents implements Listener {
         if( !Prism.getIgnore().event( "player-quit", event.getPlayer() ) )
             return;
 
-        RecordingQueue.addToQueue( ActionFactory.create( "player-quit", event.getPlayer(), null ) );
+        RecordingQueue.addToQueue( ActionFactory.createPlayer("player-quit", event.getPlayer(), null) );
 
         // Remove any active wands for this player
         if( Prism.playersWithActiveTools.containsKey( event.getPlayer().getName() ) ) {
@@ -175,7 +175,7 @@ public class PrismPlayerEvents implements Listener {
         if( plugin.dependencyEnabled( "Herochat" ) )
             return;
 
-        RecordingQueue.addToQueue( ActionFactory.create( "player-chat", event.getPlayer(), event.getMessage() ) );
+        RecordingQueue.addToQueue( ActionFactory.createPlayer("player-chat", event.getPlayer(), event.getMessage()) );
     }
 
     /**
@@ -186,9 +186,9 @@ public class PrismPlayerEvents implements Listener {
     public void onPlayerDropItem(final PlayerDropItemEvent event) {
         if( !Prism.getIgnore().event( "item-drop", event.getPlayer() ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "item-drop", event.getItemDrop().getItemStack(), event
+        RecordingQueue.addToQueue( ActionFactory.createItemStack("item-drop", event.getItemDrop().getItemStack(), event
                 .getItemDrop().getItemStack().getAmount(), -1, null, event.getPlayer().getLocation(), event.getPlayer()
-                .getName() ) );
+                .getName()) );
     }
 
     /**
@@ -199,8 +199,8 @@ public class PrismPlayerEvents implements Listener {
     public void onPlayerPickupItem(final PlayerPickupItemEvent event) {
         if( !Prism.getIgnore().event( "item-pickup", event.getPlayer() ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "item-pickup", event.getItem().getItemStack(), event.getItem()
-                .getItemStack().getAmount(), -1, null, event.getPlayer().getLocation(), event.getPlayer().getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createItemStack("item-pickup", event.getItem().getItemStack(), event.getItem()
+                .getItemStack().getAmount(), -1, null, event.getPlayer().getLocation(), event.getPlayer().getName()) );
     }
 
     /**
@@ -211,7 +211,7 @@ public class PrismPlayerEvents implements Listener {
     public void onPlayerExpChangeEvent(final PlayerExpChangeEvent event) {
         if( !Prism.getIgnore().event( "xp-pickup", event.getPlayer() ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "xp-pickup", event.getPlayer(), "" + event.getAmount() ) );
+        RecordingQueue.addToQueue( ActionFactory.createPlayer("xp-pickup", event.getPlayer(), "" + event.getAmount()) );
     }
 
     /**
@@ -229,8 +229,8 @@ public class PrismPlayerEvents implements Listener {
 
         final Block spot = event.getBlockClicked().getRelative( event.getBlockFace() );
         final int newId = ( cause.equals( "lava-bucket" ) ? 11 : 9 );
-        RecordingQueue.addToQueue( ActionFactory.create( cause, spot.getLocation(), spot.getTypeId(), spot.getData(),
-                newId, (byte) 0, player.getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createBlockChange(cause, spot.getLocation(), spot.getTypeId(), spot.getData(),
+                newId, (byte) 0, player.getName()) );
 
         if( plugin.getConfig().getBoolean( "prism.alerts.uses.lava" ) && event.getBucket() == Material.LAVA_BUCKET
                 && !player.hasPermission( "prism.alerts.use.lavabucket.ignore" )
@@ -258,7 +258,7 @@ public class PrismPlayerEvents implements Listener {
             liquid_type = "lava";
         }
 
-        final Handler pa = ActionFactory.create( "bucket-fill", player, liquid_type );
+        final Handler pa = ActionFactory.createPlayer("bucket-fill", player, liquid_type);
 
         // Override the location with the area taken
         pa.setX( spot.getX() );
@@ -280,8 +280,8 @@ public class PrismPlayerEvents implements Listener {
         final TeleportCause c = event.getCause();
         if( c.equals( TeleportCause.END_PORTAL ) || c.equals( TeleportCause.NETHER_PORTAL )
                 || c.equals( TeleportCause.ENDER_PEARL ) ) {
-            RecordingQueue.addToQueue( ActionFactory.create( "player-teleport", event.getPlayer(), event.getFrom(),
-                    event.getTo(), event.getCause() ) );
+            RecordingQueue.addToQueue( ActionFactory.createEntityTravel("player-teleport", event.getPlayer(), event.getFrom(),
+                    event.getTo(), event.getCause()) );
         }
     }
 
@@ -294,8 +294,8 @@ public class PrismPlayerEvents implements Listener {
         if( !Prism.getIgnore().event( "enchant-item", event.getEnchanter() ) )
             return;
         final Player player = event.getEnchanter();
-        RecordingQueue.addToQueue( ActionFactory.create( "enchant-item", event.getItem(), event.getEnchantsToAdd(),
-                event.getEnchantBlock().getLocation(), player.getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createItemStack("enchant-item", event.getItem(), event.getEnchantsToAdd(),
+                event.getEnchantBlock().getLocation(), player.getName()) );
     }
 
     /**
@@ -308,8 +308,8 @@ public class PrismPlayerEvents implements Listener {
         if( !Prism.getIgnore().event( "craft-item", player ) )
             return;
         final ItemStack item = event.getRecipe().getResult();
-        RecordingQueue.addToQueue( ActionFactory.create( "craft-item", item, 1, -1, null, player.getLocation(),
-                player.getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createItemStack("craft-item", item, 1, -1, null, player.getLocation(),
+                player.getName()) );
     }
 
     /**
@@ -382,7 +382,7 @@ public class PrismPlayerEvents implements Listener {
                 case DROPPER:
                     if( !Prism.getIgnore().event( "container-access", player ) )
                         return;
-                    RecordingQueue.addToQueue( ActionFactory.create( "container-access", block, player.getName() ) );
+                    RecordingQueue.addToQueue( ActionFactory.createBlock("container-access", block, player.getName()) );
                     break;
                 case JUKEBOX:
                     recordDiscInsert( block, player );
@@ -398,7 +398,7 @@ public class PrismPlayerEvents implements Listener {
                 case WOOD_BUTTON:
                     if( !Prism.getIgnore().event( "block-use", player ) )
                         return;
-                    RecordingQueue.addToQueue( ActionFactory.create( "block-use", block, player.getName() ) );
+                    RecordingQueue.addToQueue( ActionFactory.createBlock("block-use", block, player.getName()) );
                     break;
                 case LOG:
                     recordCocoaPlantEvent( block, player.getItemInHand(), event.getBlockFace(), player.getName() );
@@ -423,7 +423,7 @@ public class PrismPlayerEvents implements Listener {
                     if( player.getItemInHand().getType().equals( Material.FLINT_AND_STEEL ) ) {
                         if( !Prism.getIgnore().event( "tnt-prime", player ) )
                             return;
-                        RecordingQueue.addToQueue( ActionFactory.create( "tnt-prime", "tnt", block, player.getName() ) );
+                        RecordingQueue.addToQueue( ActionFactory.createUse("tnt-prime", "tnt", block, player.getName()) );
                     }
                     break;
                 default:
@@ -452,7 +452,7 @@ public class PrismPlayerEvents implements Listener {
         if( block != null && event.getAction() == Action.LEFT_CLICK_BLOCK ) {
             final Block above = block.getRelative( BlockFace.UP );
             if( above.getType().equals( Material.FIRE ) ) {
-                RecordingQueue.addToQueue( ActionFactory.create( "block-break", above, player.getName() ) );
+                RecordingQueue.addToQueue( ActionFactory.createBlock("block-break", above, player.getName()) );
             }
         }
 
@@ -464,8 +464,8 @@ public class PrismPlayerEvents implements Listener {
                                                      // soil
                 if( !Prism.getIgnore().event( "crop=trample", player ) )
                     return;
-                RecordingQueue.addToQueue( ActionFactory.create( "crop-trample", block.getRelative( BlockFace.UP ),
-                        player.getName() ) );
+                RecordingQueue.addToQueue( ActionFactory.createBlock("crop-trample", block.getRelative(BlockFace.UP),
+                        player.getName()) );
             }
         }
     }
@@ -508,7 +508,7 @@ public class PrismPlayerEvents implements Listener {
         if( inhand.getTypeId() == 351 && inhand.getDurability() == 15 ) {
             if( !Prism.getIgnore().event( "bonemeal-use", block ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "bonemeal-use", "bonemeal", block, player ) );
+            RecordingQueue.addToQueue( ActionFactory.createUse("bonemeal-use", "bonemeal", block, player) );
         }
     }
 
@@ -521,7 +521,7 @@ public class PrismPlayerEvents implements Listener {
     protected void recordMonsterEggUse(Block block, ItemStack inhand, String player) {
         if( !Prism.getIgnore().event( "spawnegg-use", block ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "spawnegg-use", "monster egg", block, player ) );
+        RecordingQueue.addToQueue( ActionFactory.createUse("spawnegg-use", "monster egg", block, player) );
     }
 
     /**
@@ -535,7 +535,7 @@ public class PrismPlayerEvents implements Listener {
         if( !Prism.getIgnore().event( "firework-launch", block ) )
             return;
         RecordingQueue
-                .addToQueue( ActionFactory.create( "firework-launch", inhand, null, block.getLocation(), player ) );
+                .addToQueue( ActionFactory.createItemStack("firework-launch", inhand, null, block.getLocation(), player) );
     }
 
     /**
@@ -546,7 +546,7 @@ public class PrismPlayerEvents implements Listener {
     protected void recordCakeEat(Block block, Player player) {
         if( !Prism.getIgnore().event( "cake-eat", block ) )
             return;
-        RecordingQueue.addToQueue( ActionFactory.create( "cake-eat", "cake", block, player.getName() ) );
+        RecordingQueue.addToQueue( ActionFactory.createUse("cake-eat", "cake", block, player.getName()) );
     }
 
     /**
@@ -567,14 +567,14 @@ public class PrismPlayerEvents implements Listener {
 
             // Record currently playing disc
             final ItemStack i = new ItemStack( jukebox.getPlaying(), 1 );
-            RecordingQueue.addToQueue( ActionFactory.create( "item-remove", i, i.getAmount(), 0, null,
-                    block.getLocation(), player.getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createItemStack("item-remove", i, i.getAmount(), 0, null,
+                    block.getLocation(), player.getName()) );
 
         } else {
 
             // Record the insert
-            RecordingQueue.addToQueue( ActionFactory.create( "item-insert", player.getItemInHand(), 1, 0, null,
-                    block.getLocation(), player.getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createItemStack("item-insert", player.getItemInHand(), 1, 0, null,
+                    block.getLocation(), player.getName()) );
 
         }
     }

--- a/src/main/java/me/botsko/prism/listeners/PrismVehicleEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismVehicleEvents.java
@@ -46,7 +46,7 @@ public class PrismVehicleEvents implements Listener {
         if( player != null ) {
             if( !Prism.getIgnore().event( "vehicle-place", loc.getWorld(), player ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "vehicle-place", vehicle, player ) );
+            RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-place", vehicle, player) );
         }
     }
 
@@ -64,13 +64,13 @@ public class PrismVehicleEvents implements Listener {
             if( attacker instanceof Player ) {
                 if( !Prism.getIgnore().event( "vehicle-break", ( (Player) attacker ) ) )
                     return;
-                RecordingQueue.addToQueue( ActionFactory.create( "vehicle-break", vehicle,
-                        ( (Player) attacker ).getName() ) );
+                RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-break", vehicle,
+                        ((Player) attacker).getName()) );
             } else {
                 if( !Prism.getIgnore().event( "vehicle-break", attacker.getWorld() ) )
                     return;
-                RecordingQueue.addToQueue( ActionFactory.create( "vehicle-break", vehicle, attacker.getType().name()
-                        .toLowerCase() ) );
+                RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-break", vehicle, attacker.getType().name()
+                        .toLowerCase()) );
             }
         } else {
 
@@ -79,8 +79,8 @@ public class PrismVehicleEvents implements Listener {
             if( passenger != null && passenger instanceof Player ) {
                 if( !Prism.getIgnore().event( "vehicle-break", ( (Player) passenger ) ) )
                     return;
-                RecordingQueue.addToQueue( ActionFactory.create( "vehicle-break", vehicle,
-                        ( (Player) passenger ).getName() ) );
+                RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-break", vehicle,
+                        ((Player) passenger).getName()) );
             }
         }
     }
@@ -98,12 +98,12 @@ public class PrismVehicleEvents implements Listener {
         if( entity instanceof Player ) {
             if( !Prism.getIgnore().event( "vehicle-enter", ( (Player) entity ) ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "vehicle-enter", vehicle, ( (Player) entity ).getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-enter", vehicle, ((Player) entity).getName()) );
         } else {
             if( !Prism.getIgnore().event( "vehicle-enter", entity.getWorld() ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "vehicle-enter", vehicle, entity.getType().name()
-                    .toLowerCase() ) );
+            RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-enter", vehicle, entity.getType().name()
+                    .toLowerCase()) );
         }
     }
 
@@ -120,12 +120,12 @@ public class PrismVehicleEvents implements Listener {
         if( entity instanceof Player ) {
             if( !Prism.getIgnore().event( "vehicle-enter", ( (Player) entity ) ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "vehicle-exit", vehicle, ( (Player) entity ).getName() ) );
+            RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-exit", vehicle, ((Player) entity).getName()) );
         } else {
             if( !Prism.getIgnore().event( "vehicle-enter", entity.getWorld() ) )
                 return;
-            RecordingQueue.addToQueue( ActionFactory.create( "vehicle-exit", vehicle, entity.getType().name()
-                    .toLowerCase() ) );
+            RecordingQueue.addToQueue( ActionFactory.createVehicle("vehicle-exit", vehicle, entity.getType().name()
+                    .toLowerCase()) );
         }
     }
 }

--- a/src/main/java/me/botsko/prism/listeners/PrismWorldEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismWorldEvents.java
@@ -3,7 +3,6 @@ package me.botsko.prism.listeners;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionFactory;
 import me.botsko.prism.actionlibs.RecordingQueue;
-import me.botsko.prism.utils.BlockUtils;
 
 import org.bukkit.TreeType;
 import org.bukkit.block.BlockState;
@@ -33,7 +32,7 @@ public class PrismWorldEvents implements Listener {
                 if( event.getPlayer() != null ) {
                     player = event.getPlayer().getName();
                 }
-                RecordingQueue.addToQueue( ActionFactory.create( type, block, player ) );
+                RecordingQueue.addToQueue( ActionFactory.createGrow(type, block, player) );
             }
         }
     }

--- a/src/main/java/me/botsko/prism/listeners/self/PrismMiscEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/self/PrismMiscEvents.java
@@ -29,8 +29,8 @@ public class PrismMiscEvents implements Listener {
         if( !blockStateChanges.isEmpty() ) {
 
             // Create an entry for the rollback as a whole
-            final Handler primaryAction = ActionFactory.create( "prism-process", PrismProcessType.DRAIN,
-                    event.onBehalfOf(), "" + event.getRadius() );
+            final Handler primaryAction = ActionFactory.createPrismProcess("prism-process", PrismProcessType.DRAIN,
+                    event.onBehalfOf(), "" + event.getRadius());
             final int id = RecordingTask.insertActionIntoDatabase( primaryAction );
             if( id == 0 ) { return; }
             for ( final BlockStateChange stateChange : blockStateChanges ) {
@@ -39,8 +39,8 @@ public class PrismMiscEvents implements Listener {
                 final BlockState newBlock = stateChange.getNewBlock();
 
                 // Build the action
-                RecordingQueue.addToQueue( ActionFactory.create( "prism-drain", orig, newBlock, event.onBehalfOf()
-                        .getName(), id ) );
+                RecordingQueue.addToQueue( ActionFactory.createPrismRollback("prism-drain", orig, newBlock, event.onBehalfOf()
+                        .getName(), id) );
 
             }
             // ActionQueue.save();
@@ -59,8 +59,8 @@ public class PrismMiscEvents implements Listener {
         if( !blockStateChanges.isEmpty() ) {
 
             // Create an entry for the rollback as a whole
-            final Handler primaryAction = ActionFactory.create( "prism-process", PrismProcessType.EXTINGUISH,
-                    event.onBehalfOf(), "" + event.getRadius() );
+            final Handler primaryAction = ActionFactory.createPrismProcess("prism-process", PrismProcessType.EXTINGUISH,
+                    event.onBehalfOf(), "" + event.getRadius());
             final int id = RecordingTask.insertActionIntoDatabase( primaryAction );
             if( id == 0 ) { return; }
             for ( final BlockStateChange stateChange : blockStateChanges ) {
@@ -69,8 +69,8 @@ public class PrismMiscEvents implements Listener {
                 final BlockState newBlock = stateChange.getNewBlock();
 
                 // Build the action
-                RecordingQueue.addToQueue( ActionFactory.create( "prism-extinguish", orig, newBlock, event.onBehalfOf()
-                        .getName(), id ) );
+                RecordingQueue.addToQueue( ActionFactory.createPrismRollback("prism-extinguish", orig, newBlock, event.onBehalfOf()
+                        .getName(), id) );
 
             }
             // ActionQueue.save();

--- a/src/main/java/me/botsko/prism/listeners/self/PrismRollbackEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/self/PrismRollbackEvents.java
@@ -19,7 +19,7 @@ public class PrismRollbackEvents implements Listener {
         // if(!blockStateChanges.isEmpty()){
         //
         // // Create an entry for the rollback as a whole
-        // Handler primaryAction = ActionFactory.create("prism-process",
+        // Handler primaryAction = ActionFactory.createBlock("prism-process",
         // PrismProcessType.ROLLBACK, event.onBehalfOf(),
         // event.getCommandParams() );
         // int id = ActionQueue.insertActionIntoDatabase( primaryAction );

--- a/src/main/java/me/botsko/prism/utils/MiscUtils.java
+++ b/src/main/java/me/botsko/prism/utils/MiscUtils.java
@@ -1,5 +1,6 @@
 package me.botsko.prism.utils;
 
+import com.google.common.base.CaseFormat;
 import com.helion3.pste.api.Paste;
 import com.helion3.pste.api.PsteApi;
 import com.helion3.pste.api.Results;
@@ -9,6 +10,8 @@ import me.botsko.prism.appliers.PrismProcessType;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
@@ -128,5 +131,13 @@ public class MiscUtils {
             String processedCommand = command.replace("<alert>", stripped);
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), processedCommand);
         }
+    }
+
+    public static String getEntityName(Entity entity) {
+        if(entity == null)
+            return "unknown";
+        if(entity.getType() == EntityType.PLAYER)
+            return ((Player)entity).getName();
+        return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, entity.getType().name());
     }
 }


### PR DESCRIPTION
Or rather, only log valid cases
Fun fact, a sheep activating redstone got logged as sheep-eat

Also fixes enderman action logging, was broken since creation

Bug was introduced by Bukkit/CraftBukkit@28c44287
