### PR TITLE
Log maximum health for horses

### DIFF
--- a/src/main/java/me/botsko/prism/actions/EntityAction.java
+++ b/src/main/java/me/botsko/prism/actions/EntityAction.java
@@ -43,6 +43,7 @@ public class EntityAction extends GenericAction {
         public double jump;
         public String saddle;
         public String armor;
+        public double maxHealth;
     }
 
     /**
@@ -133,6 +134,7 @@ public class EntityAction extends GenericAction {
                 this.actionData.dom = h.getDomestication();
                 this.actionData.maxDom = h.getMaxDomestication();
                 this.actionData.jump = h.getJumpStrength();
+                this.actionData.maxHealth = h.getMaxHealth();
 
                 final HorseInventory hi = h.getInventory();
 
@@ -316,6 +318,14 @@ public class EntityAction extends GenericAction {
     }
 
     /**
+     *
+     * @return
+     */
+    public double getMaxHealth() {
+        return this.actionData.maxHealth;
+    }
+
+    /**
 	 * 
 	 */
     @Override
@@ -410,6 +420,7 @@ public class EntityAction extends GenericAction {
                 h.setDomestication( this.actionData.dom );
                 h.setMaxDomestication( this.actionData.maxDom );
                 h.setJumpStrength( this.actionData.jump );
+                h.setMaxHealth( this.actionData.maxHealth );
 
                 // Stuff
                 h.getInventory().setSaddle( getSaddle() );


### PR DESCRIPTION
Horses have different maximum healths (15 - 30 HP according to the wiki). Prism does not at the moment log horses' maximum health. If a horse death is rolled back, the horse in question has its maximum health set to 52 HP (or 26 hearts).

This PR stores the maximum health in the database whenever a horse is killed, and uses that value when rolling back a horse. This way, the horse's maximum health is what it was before it was killed instead of 52.
