### PR TITLE
Store cat taming information and improve nice names

### DIFF
--- a/src/main/java/me/botsko/prism/actions/EntityAction.java
+++ b/src/main/java/me/botsko/prism/actions/EntityAction.java
@@ -35,7 +35,6 @@ public class EntityAction extends GenericAction {
         public String saddle;
         public String armor;
         public double maxHealth;
-        public String catType;
     }
 
     /**
@@ -131,7 +130,7 @@ public class EntityAction extends GenericAction {
                 }
 
                 // Cat type
-                this.actionData.catType = ocelot.getCatType().toString().toLowerCase();
+                this.actionData.var = ocelot.getCatType().toString().toLowerCase();
 
                 // Sitting
                 if ( ocelot.isSitting() ) {
@@ -262,7 +261,7 @@ public class EntityAction extends GenericAction {
      * @return
      */
     public Ocelot.Type getCatType() {
-        return Ocelot.Type.valueOf( actionData.catType.toUpperCase() );
+        return Ocelot.Type.valueOf( actionData.var.toUpperCase() );
     }
 
     /**
@@ -284,7 +283,11 @@ public class EntityAction extends GenericAction {
         if( actionData.taming_owner != null ) {
             name += actionData.taming_owner + "'s ";
         }
-        name += actionData.entity_name;
+        if( (actionData.entity_name.equals("ocelot") || actionData.entity_name.equals("horse")) && actionData.var != null ) {
+            name += actionData.var.toLowerCase().replace("_", " ");
+        } else {
+            name += actionData.entity_name;
+        }
         if( this.actionData.newColor != null ) {
             name += " " + this.actionData.newColor;
         }

--- a/src/main/java/me/botsko/prism/actions/EntityAction.java
+++ b/src/main/java/me/botsko/prism/actions/EntityAction.java
@@ -8,17 +8,8 @@ import me.botsko.prism.appliers.ChangeResultType;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Ageable;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Horse;
+import org.bukkit.entity.*;
 import org.bukkit.entity.Horse.Variant;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Monster;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Sheep;
-import org.bukkit.entity.Villager;
-import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Villager.Profession;
 import org.bukkit.inventory.HorseInventory;
 import org.bukkit.inventory.ItemStack;
@@ -44,6 +35,7 @@ public class EntityAction extends GenericAction {
         public String saddle;
         public String armor;
         public double maxHealth;
+        public String catType;
     }
 
     /**
@@ -122,6 +114,29 @@ public class EntityAction extends GenericAction {
                     this.actionData.sitting = true;
                 }
 
+            }
+
+            // Ocelot details
+            if( entity instanceof Ocelot ) {
+                final Ocelot ocelot = (Ocelot) entity;
+
+                // Owner
+                if( ocelot.isTamed() ) {
+                    if( ocelot.getOwner() instanceof Player ) {
+                        this.actionData.taming_owner = ocelot.getOwner().getName();
+                    }
+                    if( ocelot.getOwner() instanceof OfflinePlayer ) {
+                        this.actionData.taming_owner = ocelot.getOwner().getName();
+                    }
+                }
+
+                // Cat type
+                this.actionData.catType = ocelot.getCatType().toString().toLowerCase();
+
+                // Sitting
+                if ( ocelot.isSitting() ) {
+                    this.actionData.sitting = true;
+                }
             }
 
             // Horse details
@@ -240,6 +255,14 @@ public class EntityAction extends GenericAction {
      */
     public String getCustomName() {
         return this.actionData.custom_name;
+    }
+
+    /**
+     *
+     * @return
+     */
+    public Ocelot.Type getCatType() {
+        return Ocelot.Type.valueOf( actionData.catType.toUpperCase() );
     }
 
     /**
@@ -396,6 +419,36 @@ public class EntityAction extends GenericAction {
 
                 if( isSitting() ) {
                     wolf.setSitting( true );
+                }
+            }
+
+            // Set ocelot details
+            if( entity instanceof Ocelot ) {
+
+                // Owner
+                final Ocelot ocelot = (Ocelot) entity;
+                final String tamingOwner = getTamingOwner();
+                if( tamingOwner != null ) {
+                    Player owner = plugin.getServer().getPlayer( tamingOwner );
+                    if( owner == null ) {
+                        final OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer( tamingOwner );
+                        if( offlinePlayer.hasPlayedBefore() ) {
+                            owner = offlinePlayer.getPlayer();
+                        }
+                    }
+                    if( owner != null ) {
+                        ocelot.setOwner(owner);
+                    }
+                }
+
+                // Cat type
+                if( getCatType() != null ) {
+                    ocelot.setCatType( getCatType() );
+                }
+
+                // Sitting
+                if ( isSitting() ) {
+                    ocelot.setSitting( true );
                 }
             }
 


### PR DESCRIPTION
Ocelot taming information (owner, cat type, sitting) wasn't stored, which this PR fixes.

This PR also improves the "nice names" for cats and horses (the two entities that have variants): instead of "ocelot", lookups now show the cat type (which can be either "wild ocelot", "red cat", "black cat", "siamese cat") and the horse type ("horse", "donkey", "mule", "undead horse", "skeleton horse") instead of "horse". These values are based on the Bukkit enums ([ocelot](http://jd.bukkit.org/beta/apidocs/index.html?org/bukkit/entity/Ocelot.Type.html) and [horse](http://jd.bukkit.org/beta/apidocs/index.html?org/bukkit/entity/Horse.Variant.html)).
