### PR TITLE
Change date format to include leading zeros

### DIFF
--- a/src/main/java/me/botsko/prism/actions/GenericAction.java
+++ b/src/main/java/me/botsko/prism/actions/GenericAction.java
@@ -186,7 +186,7 @@ public class GenericAction implements Handler {
         final SimpleDateFormat date = new SimpleDateFormat( "yy/MM/dd" );
         this.display_date = date.format( action_time );
 
-        final SimpleDateFormat time = new SimpleDateFormat( "h:m:sa" );
+        final SimpleDateFormat time = new SimpleDateFormat( "hh:mm:ssa" );
         this.display_time = time.format( action_time );
 
     }


### PR DESCRIPTION
A leading zero now appears if the second, minute, or hour in the time is a single digit.

Example: http://gyazo.com/1b89ca1c63bb7440c605e7591cce5d03
