### PR TITLE
Fix NPE when WhatCommand is used in console

### DIFF
--- a/src/main/java/me/botsko/prism/commands/WhatCommand.java
+++ b/src/main/java/me/botsko/prism/commands/WhatCommand.java
@@ -30,7 +30,7 @@ public class WhatCommand extends Executor {
         /**
          * /prism about
          */
-        addSub( new String[] { "about", "default" }, "prism.help" ).allowConsole().setHandler( new SubHandler() {
+        addSub( new String[] { "about", "default" }, "prism.help" ).setHandler( new SubHandler() {
             @Override
             public void handle(CallInfo call) {
                 final ItemStack item = call.getPlayer().getItemInHand();

--- a/src/main/java/me/botsko/prism/commands/WhatCommand.java
+++ b/src/main/java/me/botsko/prism/commands/WhatCommand.java
@@ -1,13 +1,11 @@
 package me.botsko.prism.commands;
 
-import org.bukkit.ChatColor;
-import org.bukkit.inventory.ItemStack;
-
 import me.botsko.prism.Prism;
 import me.botsko.prism.commandlibs.CallInfo;
 import me.botsko.prism.commandlibs.Executor;
 import me.botsko.prism.commandlibs.SubHandler;
-import me.botsko.prism.utils.ItemUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
 
@@ -23,14 +21,13 @@ public class WhatCommand extends Executor {
     }
 
     /**
-	 * 
-	 */
+     *
+     */
     private void setupCommands() {
-
         /**
-         * /prism about
+         * /what
          */
-        addSub( new String[] { "about", "default" }, "prism.help" ).setHandler( new SubHandler() {
+        addSub( "what", "prism.what" ).setHandler( new SubHandler() {
             @Override
             public void handle(CallInfo call) {
                 final ItemStack item = call.getPlayer().getItemInHand();


### PR DESCRIPTION
WhatCommand can't be used in console as it is attempting to get a player object.

[22:58:49 WARN]: Unexpected exception while parsing console command "what"
org.bukkit.command.CommandException: Unhandled exception executing command 'what' in plugin Prism v2.0.6-34

Caused by: java.lang.NullPointerException
        at me.botsko.prism.commands.WhatCommand$1.handle(WhatCommand.java:36) ~[?:?]
        at me.botsko.prism.commandlibs.Executor.onCommand(Executor.java:104) ~[?:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:44) ~[spigot.jar:git-Spigot-dbe012b-61ef214]
        ... 8 more
