### PR TITLE
Trigger an item use alert for fire charges

### DIFF
--- a/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
@@ -349,10 +349,11 @@ public class PrismBlockEvents implements Listener {
             final Player player = event.getPlayer();
 
             if( player != null ) {
-                if( cause.equals( "lighter" ) && plugin.getConfig().getBoolean( "prism.alerts.uses.lighter" )
+                if( ( cause.equals( "lighter" ) || cause.equals( "fireball" ) )
+                        && plugin.getConfig().getBoolean( "prism.alerts.uses.lighter" )
                         && !player.hasPermission( "prism.alerts.use.lighter.ignore" )
                         && !player.hasPermission( "prism.alerts.ignore" ) ) {
-                    plugin.useMonitor.alertOnItemUse( player, "used a lighter" );
+                    plugin.useMonitor.alertOnItemUse( player, "used a " + cause );
                 }
             }
 


### PR DESCRIPTION
Currently, if fires are set with fire charges, no alert is generated. While this is not a big deal (fire charges are expensive) it does allow a small amount of grief to slip under the radar for longer.
