### PR TITLE
Make sure Prism compiles against older version WE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,13 @@
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>
 			<artifactId>worldedit-bukkit</artifactId>
-			<version>7.0.0-SNAPSHOT</version>
+			<version>7.0.0-20181031.045353-19</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sk89q.worldedit</groupId>
+			<artifactId>worldedit-core</artifactId>
+			<version>7.0.0-20181031.045353-19</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
WorldEdit change the Vector system into Vector3 since https://github.com/sk89q/WorldGuard/commit/91696533cf4aa4ec8f3af0e536f883106a492484 . This commit makes sure Prism will work with WorldEdit build 3926 http://builds.enginehub.org/job/worldedit/10548, and FAWE build 102 http://ci.athion.net/job/fawe-1.13/102/ .