### PR TITLE
Make Prism reflect with the recent WorldEdit api changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,13 @@
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>
 			<artifactId>worldedit-bukkit</artifactId>
-			<version>7.0.0-SNAPSHOT</version>
+			<version>7.0.0-20181031.045353-19</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sk89q.worldedit</groupId>
+			<artifactId>worldedit-core</artifactId>
+			<version>7.0.0-20181031.045353-19</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,7 @@
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>
 			<artifactId>worldedit-bukkit</artifactId>
-			<version>7.0.0-20181031.045353-19</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.sk89q.worldedit</groupId>
-			<artifactId>worldedit-core</artifactId>
-			<version>7.0.0-20181031.045353-19</version>
+			<version>7.0.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/me/botsko/prism/bridge/PrismWorldEditLogger.java
+++ b/src/main/java/me/botsko/prism/bridge/PrismWorldEditLogger.java
@@ -12,7 +12,7 @@ import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 
-import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.world.block.BlockStateHolder;
 import com.sk89q.worldedit.extension.platform.Actor;
@@ -30,7 +30,7 @@ public class PrismWorldEditLogger extends AbstractDelegateExtent {
 	}
 
 	@Override
-    public boolean setBlock(Vector pt, BlockStateHolder newBlock) throws WorldEditException {
+    public boolean setBlock(BlockVector3 pt, BlockStateHolder newBlock) throws WorldEditException {
 		if (Prism.config.getBoolean("prism.tracking.world-edit")) {
             Location loc = BukkitAdapter.adapt(world, pt);
 			Block oldBlock = loc.getBlock();


### PR DESCRIPTION
Make sure your server uses [the newest WorldEdit development build at least #3930](http://builds.enginehub.org/job/worldedit?branch=master) otherwise "NoSuchMethodError" will be thrown.

This patch is NOT compatible with [FastAsyncWorldEdit](https://github.com/boy0001/FastAsyncWorldedit). If you still want to use FAWE, please build Prism from https://github.com/AddstarMC/Prism-Bukkit/commit/36565a331a74273f803e516cf9c12947c1901d85. More details please check #24 and https://github.com/boy0001/FastAsyncWorldedit/issues/1193.