### PR TITLE
Fix for Purge starting at 0 id

### DIFF
--- a/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionsQuery.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
 
+import me.botsko.prism.database.mysql.SelectIDQueryBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.data.BlockData;
@@ -501,7 +502,93 @@ public class ActionsQuery {
 		}
 		return process;
 	}
+	/**
+	 * Returns the minimum id found that meets the parameters
+	 * @return
+	 */
+	public int getMinIDForQuery(QueryParameters parameters){
+		Connection conn = null;
+		Statement s = null;
+		int result = 0;
+		try{
+			final SelectIDQueryBuilder idQ = new SelectIDQueryBuilder(plugin);
+			idQ.setMin();
+			parameters.setMinPrimaryKey(0);
+			parameters.setMaxPrimaryKey(0);
+			String query = idQ.getQuery(parameters,false);
+			conn = Prism.dbc();
+			if (conn != null && !conn.isClosed()) {
+				s = conn.createStatement();
+				ResultSet set  = s.executeQuery(query);
+				result = set.getInt(1);
+			}
+			else {
+				Prism.log("Prism database error. Purge cannot continue.");
+			}
+		}
+		catch (final SQLException e) {
+			plugin.handleDatabaseException(e);
+		}
+		finally {
+			if (s != null)
+				try {
+					s.close();
+				}
+				catch (final SQLException ignored) {
+				}
+			if (conn != null)
+				try {
+					conn.close();
+				}
+				catch (final SQLException ignored) {
+				}
+		}
+		return result;
+	}
 
+	/**
+	 * Returns the maximum id found that meets the parameters
+	 * @return
+	 */
+	public int getMaxIDForQuery(QueryParameters parameters){
+		Connection conn = null;
+		Statement s = null;
+		int result = 0;
+		try{
+		final SelectIDQueryBuilder idQ = new SelectIDQueryBuilder(plugin);
+		idQ.setMax();
+		parameters.setMinPrimaryKey(0);
+		parameters.setMaxPrimaryKey(0);
+		String query = idQ.getQuery(parameters,false);
+			conn = Prism.dbc();
+			if (conn != null && !conn.isClosed()) {
+				s = conn.createStatement();
+				ResultSet set  = s.executeQuery(query);
+				result = set.getInt(1);
+			}
+			else {
+				Prism.log("Prism database error. Purge cannot continue.");
+			}
+		}
+		catch (final SQLException e) {
+			plugin.handleDatabaseException(e);
+		}
+		finally {
+			if (s != null)
+				try {
+					s.close();
+				}
+				catch (final SQLException ignored) {
+				}
+			if (conn != null)
+				try {
+					conn.close();
+				}
+				catch (final SQLException ignored) {
+				}
+		}
+		return result;
+	}
 	/**
 	 * 
 	 * @return

--- a/src/main/java/me/botsko/prism/database/mysql/SelectIDQueryBuilder.java
+++ b/src/main/java/me/botsko/prism/database/mysql/SelectIDQueryBuilder.java
@@ -1,0 +1,34 @@
+package me.botsko.prism.database.mysql;
+
+import me.botsko.prism.Prism;
+
+/**
+ * THis Class will return an id set for a specific query OR it can return the min and max ID's
+ *
+ * Created for use for the Add5tar MC Minecraft server
+ * Created by benjamincharlton on 31/03/2019.
+ */
+public class SelectIDQueryBuilder extends SelectQueryBuilder {
+    /**
+     * @param plugin
+     */
+    private String select = "";
+    public SelectIDQueryBuilder(Prism plugin) {
+        super(plugin);
+        setMin();
+    }
+
+    @Override
+    protected String select() {
+        return select;
+    }
+
+    public void setMax(){
+        select  = "SELECT max(id) FROM "+tableNameData+ " ";
+    }
+
+    public void setMin(){
+        select  = "SELECT min(id) FROM "+tableNameData + " ";
+    }
+
+}

--- a/src/main/java/me/botsko/prism/purge/PurgeChunkingUtil.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeChunkingUtil.java
@@ -9,10 +9,7 @@ import me.botsko.prism.Prism;
 
 public class PurgeChunkingUtil {
 
-	/**
-	 * 
-	 * @param playername
-	 */
+
 	public static long getMinimumPrimaryKey() {
 		String prefix = Prism.config.getString("prism.mysql.prefix");
 		long id = 0;
@@ -56,10 +53,7 @@ public class PurgeChunkingUtil {
 		return id;
 	}
 
-	/**
-	 * 
-	 * @param playername
-	 */
+
 	public static long getMaximumPrimaryKey() {
 		String prefix = Prism.config.getString("prism.mysql.prefix");
 		long id = 0;
@@ -69,9 +63,8 @@ public class PurgeChunkingUtil {
 		try {
 
 			conn = Prism.dbc();
-			s = conn.prepareStatement("SELECT id FROM " + prefix + "data ORDER BY id DESC LIMIT 1;");
+			s = conn.prepareStatement("SELECT max(id) FROM " + prefix + "data");
 			rs = s.executeQuery();
-
 			if (rs.first()) {
 				id = rs.getLong(1);
 			}

--- a/src/main/java/me/botsko/prism/purge/PurgeManager.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeManager.java
@@ -57,19 +57,6 @@ final public class PurgeManager implements Runnable {
 
 			if (paramList.size() > 0) {
 
-				// Identify the minimum for chunking
-				final long minId = PurgeChunkingUtil.getMinimumPrimaryKey();
-				if (minId == 0) {
-					Prism.log("No minimum primary key could be found for purge chunking.");
-					return;
-				}
-
-				// Identify the max id for chunking
-				final long maxId = PurgeChunkingUtil.getMaximumPrimaryKey();
-				if (maxId == 0) {
-					Prism.log("No maximum primary key could be found for purge chunking.");
-					return;
-				}
 
 				int purge_tick_delay = plugin.getConfig().getInt("prism.purge.batch-tick-delay");
 				if (purge_tick_delay < 1) {
@@ -84,7 +71,7 @@ final public class PurgeManager implements Runnable {
 				Prism.log(
 						"Beginning prism database purge cycle. Will be performed in batches so we don't tie up the db...");
 				deleteTask = Bukkit.getServer().getScheduler().runTaskLaterAsynchronously(plugin,
-						new PurgeTask(plugin, paramList, purge_tick_delay, minId, maxId, new LogPurgeCallback()),
+						new PurgeTask(plugin, paramList, purge_tick_delay, new LogPurgeCallback()),
 						purge_tick_delay);
 
 			}

--- a/src/main/java/me/botsko/prism/purge/PurgeTask.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeTask.java
@@ -44,6 +44,21 @@ public class PurgeTask implements Runnable {
 	private final PurgeCallback callback;
 
 	/**
+	 * Used when we dont know the min max
+	 *
+	 * @param plugin
+	 * @param paramList
+	 * @param purge_tick_delay
+	 * @param callback
+	 */
+	public PurgeTask(Prism plugin, CopyOnWriteArrayList<QueryParameters> paramList, int purge_tick_delay,
+					 PurgeCallback callback) {
+		this.plugin = plugin;
+		this.paramList = paramList;
+		this.purge_tick_delay = purge_tick_delay;
+		this.callback = callback;
+	}
+	/**
 	 * 
 	 * @param plugin
 	 */
@@ -70,7 +85,11 @@ public class PurgeTask implements Runnable {
 
 		// Pull the next-in-line purge param
 		final QueryParameters param = paramList.get(0);
-
+		if(minId == 0 && maxId == 0){
+			//Suspect first run set the min and max
+			minId = aq.getMinIDForQuery(param);
+			maxId = aq.getMaxIDForQuery(param);
+		}
 		boolean cycle_complete = false;
 
 		// We're chunking by IDs instead of using LIMIT because


### PR DESCRIPTION
Adds a new SelectIDQuery which returns min and max id for certain query  …
This allows purge tasks to set the min and max on the first iteration.
Subsequent iterations will follow the batch processing rules. 

This needs a review from a team member before its merged