### PR TITLE
Don't default to extended lookups for radius world and global

### DIFF
--- a/src/main/java/me/botsko/prism/commands/LookupCommand.java
+++ b/src/main/java/me/botsko/prism/commands/LookupCommand.java
@@ -100,7 +100,7 @@ public class LookupCommand implements SubHandler {
 						int result_count = results.getIndexOfFirstResult();
 						for (final Handler a : paginated) {
 							final ActionMessage am = new ActionMessage(a);
-							if (parameters.allowsNoRadius() || parameters.hasFlag(Flag.EXTENDED)
+							if (parameters.hasFlag(Flag.EXTENDED)
 									|| plugin.getConfig().getBoolean("prism.messenger.always-show-extended")) {
 								am.showExtended();
 							}

--- a/src/main/java/me/botsko/prism/commands/NearCommand.java
+++ b/src/main/java/me/botsko/prism/commands/NearCommand.java
@@ -83,7 +83,7 @@ public class NearCommand implements SubHandler {
 					int result_count = results.getIndexOfFirstResult();
 					for (final Handler a : paginated) {
 						final ActionMessage am = new ActionMessage(a);
-						if (parameters.allowsNoRadius() || parameters.hasFlag(Flag.EXTENDED)
+						if (parameters.hasFlag(Flag.EXTENDED)
 								|| plugin.getConfig().getBoolean("prism.messenger.always-show-extended")) {
 							am.showExtended();
 						}

--- a/src/main/java/me/botsko/prism/commands/PageCommand.java
+++ b/src/main/java/me/botsko/prism/commands/PageCommand.java
@@ -114,7 +114,7 @@ public class PageCommand implements SubHandler {
 		int result_count = results.getIndexOfFirstResult();
 		for (final Handler a : paginated) {
 			final ActionMessage am = new ActionMessage(a);
-			if (results.getParameters().allowsNoRadius() || results.getParameters().hasFlag(Flag.EXTENDED)
+			if (results.getParameters().hasFlag(Flag.EXTENDED)
 					|| plugin.getConfig().getBoolean("prism.messenger.always-show-extended")) {
 				am.showExtended();
 			}

--- a/src/main/java/me/botsko/prism/commands/UndoCommand.java
+++ b/src/main/java/me/botsko/prism/commands/UndoCommand.java
@@ -127,7 +127,7 @@ public class UndoCommand implements SubHandler {
 				if (paginated != null) {
 					for (final Handler a : paginated) {
 						final ActionMessage am = new ActionMessage(a);
-						if (parameters.allowsNoRadius() || parameters.hasFlag(Flag.EXTENDED)
+						if (parameters.hasFlag(Flag.EXTENDED)
 								|| plugin.getConfig().getBoolean("prism.messenger.always-show-extended")) {
 							am.showExtended();
 						}


### PR DESCRIPTION
Removes the default setting of extended results for the lookup, near, page, and undo commands.