### PR TITLE
Fix action permission error and add purge logging

### DIFF
--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -101,6 +101,7 @@ public class Prism extends JavaPlugin {
 	public QueueStats queueStats;
 	public BukkitTask recordingTask;
 	public int total_records_affected = 0;
+	public long max_cycle_time = 0;
 
 	/**
 	 * DB Foreign key caches

--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -69,9 +69,11 @@ public class PreprocessArgs {
 
 		// Reject no matches
 		if (foundArgsList.isEmpty() && !optional) {
-			if (sender != null)
-				sender.sendMessage(
-						Prism.messenger.playerError("You're missing valid parameters. Use /prism ? for assistance."));
+			if (sender != null) {
+				sender.sendMessage(Prism.messenger.playerError("You're missing valid parameters. Use /prism ? for assistance."));
+			} else {
+				Prism.log("Missing valid parameters");
+			}
 			return null;
 		}
 
@@ -95,8 +97,11 @@ public class PreprocessArgs {
 				handler.process(parameters, matchedParam.getArg(), sender);
 			}
 			catch (final IllegalArgumentException e) {
-				if (sender != null)
+				if (sender != null) {
 					sender.sendMessage(Prism.messenger.playerError(e.getMessage()));
+				} else {
+					Prism.log(e.getMessage());
+				}
 				return null;
 			}
 		}
@@ -169,14 +174,18 @@ public class PreprocessArgs {
 
 		switch (result) {
 			case NotFound:
-				if (sender != null)
-					sender.sendMessage(Prism.messenger
-							.playerError("Unrecognized parameter '" + arg + "'. Use /prism ? for help."));
+				if (sender != null) {
+					sender.sendMessage(Prism.messenger.playerError("Unrecognized parameter '" + arg + "'. Use /prism ? for help."));
+				} else {
+					Prism.log( "Unrecognized parameter '" + arg + "'" );
+				}
 				break;
 			case NoPermission:
-				if (sender != null)
-					sender.sendMessage(
-							Prism.messenger.playerError("No permission for parameter '" + arg + "', skipped."));
+				if (sender != null) {
+					sender.sendMessage(Prism.messenger.playerError("No permission for parameter '" + arg + "', skipped."));
+				} else {
+					Prism.log("No permission for parameter '" + arg + "'");
+				}
 				break;
 			default:
 				break;

--- a/src/main/java/me/botsko/prism/parameters/ActionParameter.java
+++ b/src/main/java/me/botsko/prism/parameters/ActionParameter.java
@@ -59,7 +59,7 @@ public class ActionParameter extends SimplePrismParameterHandler {
 							continue;
 						}
 
-						if (!sender.hasPermission(getPermission() + "." + actionType.getName())) {
+						if (sender != null && !sender.hasPermission(getPermission() + "." + actionType.getName())) {
 							noPermission.add(actionType.getName());
 							continue;
 						}

--- a/src/main/java/me/botsko/prism/purge/LogPurgeCallback.java
+++ b/src/main/java/me/botsko/prism/purge/LogPurgeCallback.java
@@ -10,10 +10,10 @@ public class LogPurgeCallback implements PurgeCallback {
 	 */
 	@Override
 	public void cycle(QueryParameters param, int cycle_rows_affected, int total_records_affected,
-			boolean cycle_complete) {
+			boolean cycle_complete, long max_cycle_time) {
 		Prism.debug("Purge cycle cleared " + cycle_rows_affected + " rows.");
 		if (cycle_complete) {
-			Prism.log("Cleared " + total_records_affected + " rows from the database. Using:"
+			Prism.log("Cleared " + total_records_affected + " rows. Max cycle time " + max_cycle_time + " msec. Using:"
 					+ param.getOriginalCommand());
 		}
 	}

--- a/src/main/java/me/botsko/prism/purge/PurgeCallback.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeCallback.java
@@ -4,5 +4,5 @@ import me.botsko.prism.actionlibs.QueryParameters;
 
 public interface PurgeCallback {
 	void cycle(QueryParameters param, int cycle_rows_affected, int total_records_affected,
-			   boolean cycle_complete);
+			   boolean cycle_complete, long max_cycle_time);
 }

--- a/src/main/java/me/botsko/prism/purge/PurgeManager.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeManager.java
@@ -52,6 +52,7 @@ final public class PurgeManager implements Runnable {
 				if (parameters.getFoundArgs().size() > 0) {
 					parameters.setStringFromRawArgs(purgeArgs.split(" "), 0);
 					paramList.add(parameters);
+					Prism.log( "Processed parameters for database purge: " + purgeArgs );
 				}
 			}
 

--- a/src/main/java/me/botsko/prism/purge/PurgeTask.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeTask.java
@@ -81,6 +81,8 @@ public class PurgeTask implements Runnable {
 		if (paramList.isEmpty())
 			return;
 
+		long start_time = System.nanoTime();
+
 		final ActionsQuery aq = new ActionsQuery(plugin);
 
 		// Pull the next-in-line purge param
@@ -113,6 +115,9 @@ public class PurgeTask implements Runnable {
 			cycle_complete = true;
 		}
 
+        long cycle_time = (System.nanoTime() - start_time) / 1000000L; // msec
+        plugin.max_cycle_time = Math.max(plugin.max_cycle_time, cycle_time);
+
 		Prism.debug("------------------- " + param.getOriginalCommand());
 		Prism.debug("minId: " + minId);
 		Prism.debug("maxId: " + maxId);
@@ -123,7 +128,7 @@ public class PurgeTask implements Runnable {
 		Prism.debug("-------------------");
 
 		// Send cycle to callback
-		callback.cycle(param, cycle_rows_affected, plugin.total_records_affected, cycle_complete);
+		callback.cycle(param, cycle_rows_affected, plugin.total_records_affected, cycle_complete, plugin.max_cycle_time);
 
 		if (!plugin.isEnabled()) {
 			Prism.log(
@@ -140,6 +145,7 @@ public class PurgeTask implements Runnable {
 
 			// reset counts
 			plugin.total_records_affected = 0;
+			plugin.max_cycle_time = 0;
 
 			if (paramList.isEmpty())
 				return;

--- a/src/main/java/me/botsko/prism/purge/SenderPurgeCallback.java
+++ b/src/main/java/me/botsko/prism/purge/SenderPurgeCallback.java
@@ -17,13 +17,13 @@ public class SenderPurgeCallback implements PurgeCallback {
 	 */
 	@Override
 	public void cycle(QueryParameters param, int cycle_rows_affected, int total_records_affected,
-			boolean cycle_complete) {
+			boolean cycle_complete, long max_cycle_time) {
 		if (sender == null)
 			return;
 		sender.sendMessage(
 				Prism.messenger.playerSubduedHeaderMsg("Purge cycle cleared " + cycle_rows_affected + " records."));
 		if (cycle_complete) {
-			sender.sendMessage(Prism.messenger.playerHeaderMsg(total_records_affected + " records have been purged."));
+			sender.sendMessage(Prism.messenger.playerHeaderMsg(total_records_affected + " records purged. Max cycle time " + max_cycle_time + " msec."));
 		}
 	}
 


### PR DESCRIPTION
ActionParameter#process() was checking permissions without checking if the sender is a player or the console first. This caused the startup/periodic purge operation to fail when using certain parameters, and to make matters worse, it failed silently because error conditions were not logged.

Besides skipping the permission check if the command sender is not a player or the console, this change outputs error messages to the log file if there is a problem with the startup purge parameters. It also outputs when a purge parameter set is processed successfully as a confirmation.  And when the purge operation eventually runs, the maximum cycle time is logged, allowing optimization of the config parameter purge.records-per-batch.

Note that LogPurgeCallback.java, PurgeTask.java, and SenderPurgeCallback.java have Windows line endings (CRLF).
