### PR TITLE
Properly save item damage

### DIFF
--- a/src/main/java/me/botsko/prism/utils/ItemUtils.java
+++ b/src/main/java/me/botsko/prism/utils/ItemUtils.java
@@ -63,7 +63,7 @@ public class ItemUtils {
 	}
 	
 	public static int getItemDamage(ItemStack stack) {
-		ItemMeta meta = Bukkit.getItemFactory().getItemMeta(stack.getType());
+		ItemMeta meta = stack.getItemMeta();
 		
 		if(meta instanceof Damageable) {
 			Damageable d = (Damageable) meta;


### PR DESCRIPTION
Without this pr, damage saves as 0.