### PR TITLE
Relocate HikariCP to avoid conflicts with other plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,10 @@
 						<pattern>io.papermc.lib</pattern>
 						<shadedPattern>com.botsko.prism.libs.paperlib</shadedPattern>
 					</relocation>
+					<relocation>
+						<pattern>com.zaxxer.hikari</pattern>
+						<shadedPattern>com.botsko.prism.libs.hikari</shadedPattern>
+					</relocation>
 				</relocations>
 			</configuration>
 			<executions>


### PR DESCRIPTION
Had a suggestion to relocate Hikari so it avoids conflicting with other plugins that implement different versions of Hiraki so that's what this does. I've tested it on one of our servers and it's working fine.

Also confirmed that the jar contains the relocated Hiarki.