### PR TITLE
Implement a more granular hikari configuration

### DIFF
--- a/src/main/java/me/botsko/prism/database/PrismDatabaseFactory.java
+++ b/src/main/java/me/botsko/prism/database/PrismDatabaseFactory.java
@@ -1,7 +1,7 @@
 package me.botsko.prism.database;
 
 import me.botsko.prism.Prism;
-import me.botsko.prism.database.mysql.MySQLPrismDataSource;
+import me.botsko.prism.database.mysql.MySqlPrismDataSource;
 import me.botsko.prism.database.sql.SQLPrismDataSourceUpdater;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.ConfigurationSection;
@@ -23,7 +23,7 @@ public class PrismDatabaseFactory {
         } else {
             mysql = configuration.createSection("prism.mysql");
         }
-        MySQLPrismDataSource.updateDefaultConfig(mysql);
+        MySqlPrismDataSource.updateDefaultConfig(mysql);
         addDatabaseDefaults(mysql);
     }
 
@@ -44,7 +44,7 @@ public class PrismDatabaseFactory {
             case "mysql":
                 Prism.log("Attempting to configure datasource as " + dataSource);
                 ConfigurationSection section = configuration.getConfigurationSection("prism.mysql");
-                database = new MySQLPrismDataSource(section);
+                database = new MySqlPrismDataSource(section);
                 return database;
             case "derby":
                 Prism.warn("ERROR: This version of Prism no longer supports Derby. Please use MySQL.");
@@ -66,7 +66,7 @@ public class PrismDatabaseFactory {
             case "mysql":
             case "derby":
             case "sqlite":
-                return new SQLPrismDataSourceUpdater((MySQLPrismDataSource) database);
+                return new SQLPrismDataSourceUpdater((MySqlPrismDataSource) database);
             default:
                 return null;
         }

--- a/src/main/java/me/botsko/prism/database/PrismDatabaseFactory.java
+++ b/src/main/java/me/botsko/prism/database/PrismDatabaseFactory.java
@@ -44,9 +44,6 @@ public class PrismDatabaseFactory {
             case "mysql":
                 Prism.log("Attempting to configure datasource as " + dataSource);
                 ConfigurationSection section = configuration.getConfigurationSection("prism.mysql");
-                String dns = "jdbc:mysql://" + section.getString("hostname") + ":"
-                        + section.getString("port") + "/" + section.getString("databaseName")
-                        + "?useUnicode=true&characterEncoding=UTF-8&useSSL=false";
                 database = new MySQLPrismDataSource(section);
                 return database;
             case "derby":

--- a/src/main/java/me/botsko/prism/database/mysql/MySQLPrismDataSource.java
+++ b/src/main/java/me/botsko/prism/database/mysql/MySQLPrismDataSource.java
@@ -7,15 +7,11 @@ import me.botsko.prism.Prism;
 import me.botsko.prism.database.sql.*;
 import me.botsko.prism.database.SelectQuery;
 import org.bukkit.configuration.ConfigurationSection;
-import sun.rmi.transport.proxy.RMIDirectSocketFactory;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;
 import java.util.Set;

--- a/src/main/java/me/botsko/prism/database/mysql/MySQLPrismDataSource.java
+++ b/src/main/java/me/botsko/prism/database/mysql/MySQLPrismDataSource.java
@@ -2,24 +2,49 @@ package me.botsko.prism.database.mysql;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.util.PropertyElf;
+import me.botsko.prism.Prism;
 import me.botsko.prism.database.sql.*;
 import me.botsko.prism.database.SelectQuery;
 import org.bukkit.configuration.ConfigurationSection;
+import sun.rmi.transport.proxy.RMIDirectSocketFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * Created for use for the Add5tar MC Minecraft server
- * Created by benjamincharlton on 5/04/2019.
+ * Created by Narimm on 5/04/2019.
  */
 public class MySQLPrismDataSource extends SQLPrismDataSource {
 
     private boolean nonStandardSQL;
-    private static HikariConfig dbconfig = new HikariConfig();
+    private static HikariConfig dbConfig = new HikariConfig();
+    private static final File propFile = new File(Prism.getInstance().getDataFolder(),
+          "hikari.properties");
 
     public MySQLPrismDataSource(ConfigurationSection section) {
         super(section);
+        if(propFile.exists()){
+            Prism.log("Configuring Hikari from " +propFile.getName());
+            Prism.log("This file will not save the jdbcURL, username or password - these are loaded"
+                  + " by default from the standard prism configuration file.  If you set these "
+                  + "explicitly in the properties file the settings in the standard config will be"
+                  + "ignored.");
+            dbConfig = new HikariConfig(propFile.getPath());
+        }
         nonStandardSQL = this.section.getBoolean("useNonStandardSql", true);
         name = "mysql";
     }
+
 
     public static void updateDefaultConfig(ConfigurationSection section) {
         section.addDefault("hostname", "127.0.0.1");
@@ -29,20 +54,54 @@ public class MySQLPrismDataSource extends SQLPrismDataSource {
         section.addDefault("prefix", "prism_");
         section.addDefault("port", "3306");
         section.addDefault("useNonStandardSql", true);
+        setupDefaultProperties(section);
     }
+
+    private static void setupDefaultProperties(@Nonnull ConfigurationSection section) {
+        int maxPool = section.getInt("database.max-pool-connections", 10);
+        int minIdle = section.getInt("database.min-idle-connections", 10);
+        if (!propFile.exists()) {
+            dbConfig.addDataSourceProperty("maximumPoolSize", maxPool);
+            dbConfig.addDataSourceProperty("minimumIdle", minIdle);
+            dbConfig.setMaximumPoolSize(maxPool);
+            dbConfig.setMinimumIdle(minIdle);
+        }
+        if (!propFile.exists()) {
+            dbConfig.setPoolName("prism");
+            Properties prop = new Properties();
+            Set<String> keys = PropertyElf.getPropertyNames(HikariConfig.class);
+            for(String k:keys){
+                if(k.equals("jbdcUrl") || k.equals("username")||k.equals("password"))
+                    continue;
+                Object out  = PropertyElf.getProperty(k,dbConfig);
+                prop.setProperty(k,out.toString());
+            }
+            Properties datasourceProps = dbConfig.getDataSourceProperties();
+            for (String name:datasourceProps.stringPropertyNames()) {
+                prop.setProperty("dataSource."+name, datasourceProps.getProperty(name));
+            }
+            try {
+                OutputStream out = new FileOutputStream(propFile);
+                prop.store(out, "Prism Hikari Datasource Properties for"
+                      + " advanced database Configuration");
+                Prism.log("Database Configuration saved to - " + propFile.getPath());
+            } catch (IOException e) {
+                Prism.log("Could not save Hikari.properties - " + e.getMessage());
+            }
+        }
+    }
+
     @Override
     public MySQLPrismDataSource createDataSource() {
-        final String dns = "jdbc:mysql://" + this.section.getString("hostname") + ":"
-                + this.section.getString("port") + "/" + this.section.getString("databaseName")
-                + "?useUnicode=true&characterEncoding=UTF-8&useSSL=false";
-
-        dbconfig.setPoolName("prism");
-        dbconfig.setMaximumPoolSize(this.section.getInt("database.max-pool-connections"));
-        dbconfig.setMinimumIdle(this.section.getInt("database.min-idle-connections"));
-        dbconfig.setJdbcUrl(dns);
-        dbconfig.setUsername(this.section.getString("username"));
-        dbconfig.setPassword(this.section.getString("password"));
-        database = new HikariDataSource(dbconfig);
+        if(dbConfig.getJdbcUrl() == null) {
+            final String dns = "jdbc:mysql://" + this.section.getString("hostname") + ":"
+                  + this.section.getString("port") + "/" + this.section.getString("databaseName")
+                  + "?useUnicode=true&characterEncoding=UTF-8&useSSL=false";
+            dbConfig.setJdbcUrl(dns);
+            dbConfig.setUsername(this.section.getString("username"));
+            dbConfig.setPassword(this.section.getString("password"));
+        }
+        database = new HikariDataSource(dbConfig);
         createSettingsQuery();
         return this;
     }

--- a/src/main/java/me/botsko/prism/database/mysql/MySqlPrismDataSource.java
+++ b/src/main/java/me/botsko/prism/database/mysql/MySqlPrismDataSource.java
@@ -4,8 +4,9 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.util.PropertyElf;
 import me.botsko.prism.Prism;
-import me.botsko.prism.database.sql.*;
 import me.botsko.prism.database.SelectQuery;
+import me.botsko.prism.database.sql.SQLPrismDataSource;
+import me.botsko.prism.database.sql.SQLSelectQueryBuilder;
 import org.bukkit.configuration.ConfigurationSection;
 
 import javax.annotation.Nonnull;
@@ -20,28 +21,42 @@ import java.util.Set;
  * Created for use for the Add5tar MC Minecraft server
  * Created by Narimm on 5/04/2019.
  */
-public class MySQLPrismDataSource extends SQLPrismDataSource {
+public class MySqlPrismDataSource extends SQLPrismDataSource {
 
-    private boolean nonStandardSQL;
-    private static HikariConfig dbConfig = new HikariConfig();
     private static final File propFile = new File(Prism.getInstance().getDataFolder(),
           "hikari.properties");
+    private static HikariConfig dbConfig;
 
-    public MySQLPrismDataSource(ConfigurationSection section) {
-        super(section);
-        if(propFile.exists()){
-            Prism.log("Configuring Hikari from " +propFile.getName());
+    static {
+        if (propFile.exists()) {
+            Prism.log("Configuring Hikari from " + propFile.getName());
             Prism.log("This file will not save the jdbcURL, username or password - these are loaded"
                   + " by default from the standard prism configuration file.  If you set these "
                   + "explicitly in the properties file the settings in the standard config will be"
                   + "ignored.");
             dbConfig = new HikariConfig(propFile.getPath());
+        } else {
+            dbConfig = new HikariConfig();
         }
-        nonStandardSQL = this.section.getBoolean("useNonStandardSql", true);
+    }
+
+    private boolean nonStandardSql;
+
+    /**
+     * Setup the Datasource.
+     *
+     * @param section a {@link ConfigurationSection}
+     */
+    public MySqlPrismDataSource(ConfigurationSection section) {
+        super(section);
+        nonStandardSql = section.getBoolean("useNonStandardSql", true);
         name = "mysql";
     }
 
-
+    /**
+     * The adds the new requirements to an old configuration file.
+     * @param section a {@link ConfigurationSection}
+     */
     public static void updateDefaultConfig(ConfigurationSection section) {
         section.addDefault("hostname", "127.0.0.1");
         section.addDefault("username", "root");
@@ -66,15 +81,16 @@ public class MySQLPrismDataSource extends SQLPrismDataSource {
             dbConfig.setPoolName("prism");
             Properties prop = new Properties();
             Set<String> keys = PropertyElf.getPropertyNames(HikariConfig.class);
-            for(String k:keys){
-                if(k.equals("jbdcUrl") || k.equals("username")||k.equals("password"))
+            for (String k : keys) {
+                if ("jbdcUrl".equals(k) || "username".equals(k) || "password".equals(k)) {
                     continue;
-                Object out  = PropertyElf.getProperty(k,dbConfig);
-                prop.setProperty(k,out.toString());
+                }
+                Object out = PropertyElf.getProperty(k, dbConfig);
+                prop.setProperty(k, out.toString());
             }
             Properties datasourceProps = dbConfig.getDataSourceProperties();
-            for (String name:datasourceProps.stringPropertyNames()) {
-                prop.setProperty("dataSource."+name, datasourceProps.getProperty(name));
+            for (String name : datasourceProps.stringPropertyNames()) {
+                prop.setProperty("dataSource." + name, datasourceProps.getProperty(name));
             }
             try {
                 OutputStream out = new FileOutputStream(propFile);
@@ -88,8 +104,8 @@ public class MySQLPrismDataSource extends SQLPrismDataSource {
     }
 
     @Override
-    public MySQLPrismDataSource createDataSource() {
-        if(dbConfig.getJdbcUrl() == null) {
+    public MySqlPrismDataSource createDataSource() {
+        if (dbConfig.getJdbcUrl() == null) {
             final String dns = "jdbc:mysql://" + this.section.getString("hostname") + ":"
                   + this.section.getString("port") + "/" + this.section.getString("databaseName")
                   + "?useUnicode=true&characterEncoding=UTF-8&useSSL=false";
@@ -109,7 +125,7 @@ public class MySQLPrismDataSource extends SQLPrismDataSource {
 
     @Override
     public SelectQuery createSelectQuery() {
-        if (nonStandardSQL) {
+        if (nonStandardSql) {
             return new MySQLSelectQueryBuilder(this);
         } else {
             return new SQLSelectQueryBuilder(this);

--- a/src/main/java/me/botsko/prism/database/sql/SQLPrismDataSourceUpdater.java
+++ b/src/main/java/me/botsko/prism/database/sql/SQLPrismDataSourceUpdater.java
@@ -1,7 +1,7 @@
 package me.botsko.prism.database.sql;
 
 import me.botsko.prism.database.PrismDataSourceUpdater;
-import me.botsko.prism.database.mysql.MySQLPrismDataSource;
+import me.botsko.prism.database.mysql.MySqlPrismDataSource;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -13,9 +13,9 @@ import java.sql.Statement;
  * Created by benjamincharlton on 5/04/2019.
  */
 public class SQLPrismDataSourceUpdater implements PrismDataSourceUpdater {
-    private MySQLPrismDataSource dataSource;
+    private MySqlPrismDataSource dataSource;
 
-    public SQLPrismDataSourceUpdater(MySQLPrismDataSource dataSource) {
+    public SQLPrismDataSourceUpdater(MySqlPrismDataSource dataSource) {
         this.dataSource = dataSource;
     }
 


### PR DESCRIPTION
This creates a default `hikari.properties` file and fills it with default values with the exception of the `jbdcUrl`, `username` and `password`.

These values are loaded by default from the standard prism config.  However, if the user sets a `jbdcUrl`, `username` or `password`  in the 'hikari.properties' file it will be the default and the prism config will be ignored.  

This allows users to set custom urls using varied drivers and url settings.

Signed-off-by: Narimm <benjicharlton@gmail.com>