### PR TITLE
Update bStats to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>1.4</version>
+            <version>1.7</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>

--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -144,7 +144,8 @@ public class Prism extends JavaPlugin {
 
 		if (getConfig().getBoolean("prism.allow-metrics")) {
 			Prism.log("Prism bStats metrics are enabled - thank you!");
-			Metrics metrics = new Metrics(this);
+			int pluginid = 4365; // assigned by bstats.org
+			Metrics metrics = new Metrics(this, pluginid);
 			if (metrics == null || !metrics.isEnabled()) {
 				Prism.warn("bStats failed to initialise! Please check Prism/bStats configs.");
 			}


### PR DESCRIPTION
With the removal of json-simple, bStats version 1.7 is working now.

Fixes #106 

![prism_metrics](https://user-images.githubusercontent.com/3617206/75254697-c0469a80-57ae-11ea-8eee-bac6e32b3ee5.png)
