### PR TITLE
Fix off by one error in inventory rollback

### DIFF
--- a/src/main/java/me/botsko/prism/actions/ItemStackAction.java
+++ b/src/main/java/me/botsko/prism/actions/ItemStackAction.java
@@ -632,7 +632,7 @@ public class ItemStackAction extends GenericAction {
 					// We'll attempt to take it from the same slot
 					if (iSlot >= 0) {
 
-						if (iSlot > inventory.getContents().length) {
+						if (iSlot >= inventory.getContents().length) {
 							inventory.addItem(getItem());
 						}
 						else {


### PR DESCRIPTION
This fixes an "off-by-one" error in inventory rollbacks.

It was causing this error and this change fixes it (has been tested):
```
[WARN]: java.lang.ArrayIndexOutOfBoundsException: 27
[WARN]:        at java.util.Arrays$ArrayList.get(Arrays.java:3841)
[WARN]:        at net.minecraft.server.v1_15_R1.NonNullList.get(SourceFile:46)
[WARN]:        at net.minecraft.server.v1_15_R1.TileEntityLootable.getItem(TileEntityLootable.java:81)
[WARN]:        at org.bukkit.craftbukkit.v1_15_R1.inventory.CraftInventory.getItem(CraftInventory.java:49)
[WARN]:        at me.botsko.prism.actions.ItemStackAction.placeItems(ItemStackAction.java:639)
[WARN]:        at me.botsko.prism.actions.ItemStackAction.applyRollback(ItemStackAction.java:384)
[WARN]:        at me.botsko.prism.appliers.Preview.lambda$processWorldChanges$0(Preview.java:299)
[WARN]:        at org.bukkit.craftbukkit.v1_15_R1.scheduler.CraftTask.run(CraftTask.java:84)
[WARN]:        at org.bukkit.craftbukkit.v1_15_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:452)
[WARN]:        at net.minecraft.server.v1_15_R1.MinecraftServer.b(MinecraftServer.java:1246)
[WARN]:        at net.minecraft.server.v1_15_R1.DedicatedServer.b(DedicatedServer.java:430)
[WARN]:        at net.minecraft.server.v1_15_R1.MinecraftServer.a(MinecraftServer.java:1164)
[WARN]:        at net.minecraft.server.v1_15_R1.MinecraftServer.run(MinecraftServer.java:958)
[WARN]:        at java.lang.Thread.run(Thread.java:748)
```