### PR TITLE
Fix delete command to work like purge task

### DIFF
--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -628,9 +628,7 @@ public class Prism extends JavaPlugin {
     public void launchScheduledPurgeManager() {
         final List<String> purgeRules = getConfig().getStringList("prism.db-records-purge-rules");
         purgeManager = new PurgeManager(this, purgeRules);
-        // scheduledPurgeExecutor =
         schedulePool.scheduleAtFixedRate(purgeManager, 0, 12, TimeUnit.HOURS);
-        // scheduledPurgeExecutor.cancel();
     }
 
     /**

--- a/src/main/java/me/botsko/prism/database/sql/SQLDeleteQueryBuilder.java
+++ b/src/main/java/me/botsko/prism/database/sql/SQLDeleteQueryBuilder.java
@@ -55,9 +55,10 @@ public class SQLDeleteQueryBuilder extends SQLSelectQueryBuilder implements Dele
             dataSource.setPaused(true); //pause so that the database cannot process the queue.
         int total_rows_affected = 0;
         int cycle_rows_affected = 0;
+
         try (
                 Connection connection = dataSource.getDataSource().getConnection();
-                Statement s = connection.createStatement()
+                Statement s = connection.createStatement();
         ) {
             cycle_rows_affected = s.executeUpdate(getQuery(parameters, shouldGroup));
             total_rows_affected += cycle_rows_affected;

--- a/src/main/java/me/botsko/prism/purge/PurgeTask.java
+++ b/src/main/java/me/botsko/prism/purge/PurgeTask.java
@@ -125,7 +125,8 @@ public class PurgeTask implements Runnable {
         long cycleTime = (System.nanoTime() - startTime) / 1000000L; // msec
         plugin.max_cycle_time = Math.max(plugin.max_cycle_time, cycleTime);
 
-		Prism.debug("------------------- " + param.getOriginalCommand());
+		Prism.debug("------------------- ");
+		Prism.debug("params: " + param.getOriginalCommand());
 		Prism.debug("minId: " + minId);
 		Prism.debug("maxId: " + maxId);
 		Prism.debug("newMinId: " + newMinId);


### PR DESCRIPTION
## Changes
This updates how the `/prism delete` sub-command works to be just like the auto purge task. It uses the same functionality and launches a background purge task to perform the work. No work is done on the main thread.

## Testing
This has been substantially tested on one of our servers and I have validated it caused no errors and zero main thread lag.