### PR TITLE
Relocate HikariCP (again) - Fixes #138

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,10 @@
 						<pattern>org.kitteh.pastegg</pattern>
 						<shadedPattern>com.botsko.prism.libs.pastegg</shadedPattern>
 					</relocation>
+					<relocation>
+						<pattern>com.zaxxer.hikari</pattern>
+						<shadedPattern>com.botsko.prism.libs.hikari</shadedPattern>
+					</relocation>
 				</relocations>
 			</configuration>
 			<executions>


### PR DESCRIPTION
This shades/relocates HikariCP for compatibility purposes.

(Fixed #138 and possibly other plugin compat issues)