### PR TITLE
Shading the api caused class cast exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,10 +223,6 @@
 						<pattern>com.zaxxer.hikari</pattern>
 						<shadedPattern>com.botsko.prism.libs.hikari</shadedPattern>
 					</relocation>
-					<relocation>
-						<pattern>au.com.addstar.dripreporter</pattern>
-						<shadedPattern>com.botsko.prism.libs.dripreporter</shadedPattern>
-					</relocation>
 				</relocations>
 			</configuration>
 			<executions>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Prism
 main: me.botsko.prism.Prism
 version: ${plugin.version}
-softdepend: [WorldEdit,HeroChat]
+softdepend: [WorldEdit,HeroChat,DripReporter]
 author: AddstarMC
 authors: [add5tar, Narimm, viveleroi]
 website: https://github.com/AddstarMC/Prism-Bukkit/wiki


### PR DESCRIPTION
Also the plugin.yml diddnt specify Dripreporter as a softdepend to ensure load order was correct.

Signed-off-by: Narimm <benjicharlton@gmail.com>