### PR TITLE
Add player key index in database to speedup player lookups

### DIFF
--- a/src/main/java/me/botsko/prism/Updater.java
+++ b/src/main/java/me/botsko/prism/Updater.java
@@ -10,7 +10,7 @@ public class Updater {
 
 
     protected final Prism plugin;
-    private final int currentDbSchemaVersion = 7;
+    private final int currentDbSchemaVersion = 8;
     private final ArrayList<Runnable> updates = new ArrayList<>(currentDbSchemaVersion);
 
     /**
@@ -27,6 +27,7 @@ public class Updater {
         updates.add(prismDataSourceUpdater::v4_to_v5);
         updates.add(prismDataSourceUpdater::v5_to_v6);
         updates.add(prismDataSourceUpdater::v6_to_v7);
+        updates.add(prismDataSourceUpdater::v7_to_v8);
     }
 
     private int getClientDbSchemaVersion() {

--- a/src/main/java/me/botsko/prism/database/PrismDataSourceUpdater.java
+++ b/src/main/java/me/botsko/prism/database/PrismDataSourceUpdater.java
@@ -18,5 +18,6 @@ public interface PrismDataSourceUpdater {
 
     void v6_to_v7();
 
+    void v7_to_v8();
 }
 

--- a/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
+++ b/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
@@ -167,7 +167,8 @@ public abstract class SqlPrismDataSource implements PrismDataSource {
                     + "`z` int(11) NOT NULL," + "`block_id` mediumint(5) DEFAULT NULL,"
                     + "`block_subid` mediumint(5) DEFAULT NULL," + "`old_block_id` mediumint(5) DEFAULT NULL,"
                     + "`old_block_subid` mediumint(5) DEFAULT NULL," + "PRIMARY KEY (`id`)," + "KEY `epoch` (`epoch`),"
-                    + "KEY  `location` (`world_id`, `x`, `z`, `y`, `action_id`)"
+                    + "KEY  `location` (`world_id`, `x`, `z`, `y`, `action_id`),"
+                    + "KEY  `player` (`player_id`)"
                     + ") ENGINE=InnoDB  DEFAULT CHARSET=utf8;";
             st.executeUpdate(query);
 

--- a/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSourceUpdater.java
+++ b/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSourceUpdater.java
@@ -91,4 +91,21 @@ public class SqlPrismDataSourceUpdater implements PrismDataSourceUpdater {
             dataSource.handleDataSourceException(e);
         }
     }
+
+    @Override
+    public void v7_to_v8() {
+        // Prepare query to be used
+        String query = "ALTER TABLE `" + prefix + "data` ADD INDEX `player` (`player_id`)";
+
+        // Prepare database
+        try (
+                Connection conn = dataSource.getConnection();
+                PreparedStatement st = conn.prepareStatement(query);
+        ) {
+            // Add player index to speed up player lookups.
+            st.executeUpdate(query);
+        } catch (SQLException e) {
+            dataSource.handleDataSourceException(e);
+        }
+    }
 }


### PR DESCRIPTION
Not entirely sure if this conforms to standards and guidelines, but as I was doing some lookups the other day, I realised that all lookups involving players with global radius and insane times resulted in searches taking forever. This might help to alleviate that.