### PR TITLE
Explore the option to use FULLTEXT to speed up keyword searches

### DIFF
--- a/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
+++ b/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
@@ -182,7 +182,8 @@ public abstract class SqlPrismDataSource implements PrismDataSource {
                 query = "CREATE TABLE IF NOT EXISTS `" + prefix + "data_extra` ("
                         + "`extra_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,"
                         + "`data_id` bigint(20) unsigned NOT NULL," + "`data` text NULL," + "`te_data` text NULL,"
-                        + "PRIMARY KEY (`extra_id`)," + "KEY `data_id` (`data_id`)"
+                        + "PRIMARY KEY (`extra_id`)," + "KEY `data_id` (`data_id`),"
+                        + "FULLTEXT (`data`)"
                         + ") ENGINE=InnoDB  DEFAULT CHARSET=utf8;";
                 st.executeUpdate(query);
 

--- a/src/main/java/me/botsko/prism/database/sql/SqlSelectQueryBuilder.java
+++ b/src/main/java/me/botsko/prism/database/sql/SqlSelectQueryBuilder.java
@@ -281,7 +281,7 @@ public class SqlSelectQueryBuilder extends QueryBuilder implements SelectQuery {
         // Keyword(s)
         final String keyword = parameters.getKeyword();
         if (keyword != null) {
-            addCondition("ex.data LIKE '%" + keyword + "%'");
+            addCondition("MATCH(ex.data) AGAINST('" + keyword + "')");
         }
     }
 


### PR DESCRIPTION
Just another random PR for a minor database tweak that is either world-breakingly-bad, or positively shining depending on the reviewer.

This PR attempts to shift the keyword search argument to take advantage of FULLTEXT indexes using `MATCH()` & `AGAINST()` queries to drastically improve lookup performance for keywords like commands & chat.

The only side-effect I can see that can occur from this is that some old lookup commands need to be tweaked to ensure that the `MATCH() AGAINST()` combination of queries will return the desired results.

Second PR on this project, feel free to close this PR if it doesn't fit the goals of the project.