### PR TITLE
Track item breakage and record

### DIFF
--- a/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/src/main/java/me/botsko/prism/PrismConfig.java
@@ -158,6 +158,7 @@ public class PrismConfig extends ConfigBase {
         config.addDefault("prism.tracking.item-insert", true);
         config.addDefault("prism.tracking.item-pickup", true);
         config.addDefault("prism.tracking.item-remove", true);
+        config.addDefault("prism.tracking.item-break", false);
         config.addDefault("prism.tracking.item-rotate", true);
         config.addDefault("prism.tracking.lava-break", true);
         config.addDefault("prism.tracking.lava-bucket", true);

--- a/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
+++ b/src/main/java/me/botsko/prism/actionlibs/ActionRegistry.java
@@ -178,6 +178,7 @@ public class ActionRegistry {
         registerAction(new ActionType("item-insert", false, true, true, ItemStackAction.class, "inserted"));
         registerAction(new ActionType("item-pickup", false, true, true, ItemStackAction.class, "picked up"));
         registerAction(new ActionType("item-remove", false, true, true, ItemStackAction.class, "removed"));
+        registerAction(new ActionType("item-break",false,false,false,ItemStackAction.class,"broke"));
         registerAction(new ActionType("item-rotate", false, false, false, UseAction.class, "turned item"));
         registerAction(new ActionType("lava-break", false, true, true, BlockAction.class, "broke"));
         registerAction(new ActionType("lava-bucket", true, true, true, BlockChangeAction.class, "poured"));

--- a/src/main/java/me/botsko/prism/actionlibs/Ignore.java
+++ b/src/main/java/me/botsko/prism/actionlibs/Ignore.java
@@ -33,7 +33,8 @@ public class Ignore {
     }
 
     /**
-     * Check event typ.
+     * Check event type.  This checks to see if an event was configured for tracking - in effect it is an inverted
+     * check.  You could just call the config instead..  but this does report to debug if the action is not tracked.
      *
      * @param actionTypeName type.
      * @return boolean

--- a/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
+++ b/src/main/java/me/botsko/prism/listeners/PrismInventoryEvents.java
@@ -3,6 +3,7 @@ package me.botsko.prism.listeners;
 import me.botsko.prism.Prism;
 import me.botsko.prism.actionlibs.ActionFactory;
 import me.botsko.prism.actionlibs.RecordingQueue;
+import me.botsko.prism.actions.Handler;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -13,6 +14,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerItemBreakEvent;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
 
@@ -23,8 +25,10 @@ public class PrismInventoryEvents implements Listener {
 
     private final boolean trackingInsert;
     private final boolean trackingRemove;
+    private final boolean trackingBreaks;
     private static final String INSERT = "item-insert";
     private static final String REMOVE = "item-remove";
+    private static final String BREAK = "item-break";
     private final Prism plugin;
 
     /**
@@ -33,8 +37,10 @@ public class PrismInventoryEvents implements Listener {
      */
     public PrismInventoryEvents(Prism plugin) {
         this.plugin = plugin;
-        this.trackingInsert = plugin.getConfig().getBoolean("prism.tracking.item-insert");
-        this.trackingRemove = plugin.getConfig().getBoolean("prism.tracking.item-remove");
+        this.trackingInsert = !Prism.getIgnore().event("item-insert");
+        this.trackingRemove = !Prism.getIgnore().event("item-remove");
+        this.trackingBreaks = !Prism.getIgnore().event("item-break");
+
     }
 
     /**
@@ -263,6 +269,7 @@ public class PrismInventoryEvents implements Listener {
                         int remaining = slotItem.getAmount();
 
                         for (ItemStack is : event.getView().getBottomInventory().getStorageContents()) {
+                            //noinspection ConstantConditions  Until intellij sorts it checks
                             if (is == null || is.getType() == Material.AIR) {
                                 remaining -= stackSize;
                             } else if (is.isSimilar(slotItem)) {
@@ -357,6 +364,21 @@ public class PrismInventoryEvents implements Listener {
 
         }
         return newAmount;
+    }
+
+    /**
+     * Tracks item breakage. Cant be rolled back.  At this point the item damage is not 0 however it will be set 0 after
+     * event completes - Reported item durability will be the durability before the event.
+     * @param event PlayerItemBreakEvent.
+     */
+    @EventHandler(ignoreCancelled = true,priority = EventPriority.MONITOR)
+    public void onItemBreak(PlayerItemBreakEvent event) {
+        if (!trackingBreaks) {
+            return;
+        }
+        ItemStack item = event.getBrokenItem();
+        Handler h = ActionFactory.createItemStack(BREAK,item,null, event.getPlayer().getLocation(),event.getPlayer());
+        RecordingQueue.addToQueue(h);
     }
 
 }


### PR DESCRIPTION
Adds an event to track item breakage and record it - but this will not be revertable or able to be rolledback.  The item recorded will have the prebreak durability recorded but is then set as 0.  The stack size will also be 0 at the time this is recorded.
Close #161 