### PR TITLE
Separate out action key index from location to speed up lookups

### DIFF
--- a/src/main/java/me/botsko/prism/Updater.java
+++ b/src/main/java/me/botsko/prism/Updater.java
@@ -10,7 +10,7 @@ public class Updater {
 
 
     protected final Prism plugin;
-    private final int currentDbSchemaVersion = 8;
+    private final int currentDbSchemaVersion = 9;
     private final ArrayList<Runnable> updates = new ArrayList<>(currentDbSchemaVersion);
 
     /**
@@ -28,6 +28,7 @@ public class Updater {
         updates.add(prismDataSourceUpdater::v5_to_v6);
         updates.add(prismDataSourceUpdater::v6_to_v7);
         updates.add(prismDataSourceUpdater::v7_to_v8);
+        updates.add(prismDataSourceUpdater::v8_to_v9);
     }
 
     private int getClientDbSchemaVersion() {

--- a/src/main/java/me/botsko/prism/database/PrismDataSourceUpdater.java
+++ b/src/main/java/me/botsko/prism/database/PrismDataSourceUpdater.java
@@ -19,5 +19,7 @@ public interface PrismDataSourceUpdater {
     void v6_to_v7();
 
     void v7_to_v8();
+
+    void v8_to_v9();
 }
 

--- a/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
+++ b/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
@@ -167,7 +167,8 @@ public abstract class SqlPrismDataSource implements PrismDataSource {
                     + "`z` int(11) NOT NULL," + "`block_id` mediumint(5) DEFAULT NULL,"
                     + "`block_subid` mediumint(5) DEFAULT NULL," + "`old_block_id` mediumint(5) DEFAULT NULL,"
                     + "`old_block_subid` mediumint(5) DEFAULT NULL," + "PRIMARY KEY (`id`)," + "KEY `epoch` (`epoch`),"
-                    + "KEY  `location` (`world_id`, `x`, `z`, `y`, `action_id`),"
+                    + "KEY  `location` (`world_id`, `x`, `z`, `y`),"
+                    + "KEY  `action` (`action_id`),"
                     + "KEY  `player` (`player_id`)"
                     + ") ENGINE=InnoDB  DEFAULT CHARSET=utf8;";
             st.executeUpdate(query);

--- a/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSourceUpdater.java
+++ b/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSourceUpdater.java
@@ -108,4 +108,30 @@ public class SqlPrismDataSourceUpdater implements PrismDataSourceUpdater {
             dataSource.handleDataSourceException(e);
         }
     }
+
+    @Override
+    public void v8_to_v9() {
+        // Declare query
+        String query = "";
+
+        // Prepare database
+        try (
+                Connection conn = dataSource.getConnection();
+                PreparedStatement st = conn.prepareStatement(query);
+        ) {
+            // Add action_id index
+            query = "ALTER TABLE `" + prefix + "data` ADD INDEX `action` (`action_id`)";
+            st.executeUpdate(query);
+
+            // Drop location index to re-create it
+            query = "ALTER TABLE `" + prefix + "data` DROP INDEX `location`";
+            st.executeUpdate(query);
+
+            // Re-create location index
+            query = "ALTER TABLE `" + prefix + "data` CREATE INDEX `location` (`world_id`, `x`, `z`, `y`)";
+            st.executeUpdate(query);
+        } catch (SQLException e) {
+            dataSource.handleDataSourceException(e);
+        }
+    }
 }


### PR DESCRIPTION
Hello there!

Yet another PR from me with some SQL index voodoo magick to help speedup lookups! Like my first PR #194, I am highly confident this PR will only bring about sunshines and rainbows to the performance of Prism.

In a nutshell, there is no reason for the `action_id` column to be in the same index as the `location`-based columns. By separating it out into it's own index, the performance gain is exponential. A simple command like `/pr lookup a:command t:1y r:global` can take about 5 seconds on my server, as compared to more than 15 minutes (_before I killed it_) without this indexing key!

Unfortunately, because of the way the database engine works, there is no way to modify an existing index, so I tried to take the approach of deleting the whole index `location` and re-creating it with the correct `location`-y columns. This may be the most expensive part about this PR, but I believe this change makes the most logical sense and should be carried out!