### PR TITLE
[Feature] Move db update to async method.

### DIFF
--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -328,14 +328,17 @@ public class Prism extends JavaPlugin {
         }
         final List<String> worldNames = getServer().getWorlds().stream()
                 .map(World::getName).collect(Collectors.toList());
+
         final String[] playerNames = Bukkit.getServer().getOnlinePlayers().stream()
                 .map(Player::getName).toArray(String[]::new);
+
         // init db async then call back to complete enable.
         final BukkitTask updating = Bukkit.getScheduler().runTaskTimerAsynchronously(instance, () -> {
             if (!isEnabled()) {
-                warn("Prism is loading and updating the database logging is NOT enabled");
+                warn("Prism is loading and updating the database; logging is NOT enabled");
             }
         },100,200);
+
         Bukkit.getScheduler().runTaskAsynchronously(instance, () -> {
             prismDataSource = PrismDatabaseFactory.createDataSource(config);
             Connection testConnection;

--- a/src/main/java/me/botsko/prism/Prism.java
+++ b/src/main/java/me/botsko/prism/Prism.java
@@ -71,7 +71,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -342,12 +341,16 @@ public class Prism extends JavaPlugin {
             Connection testConnection;
             if (prismDataSource != null) {
                 testConnection = prismDataSource.getConnection();
-                if (testConnection != null) {
-                    try {
-                        testConnection.close();
-                    } catch (final SQLException e) {
-                        prismDataSource.handleDataSourceException(e);
-                    }
+                if (testConnection == null) {
+                    notifyDisabled();
+                    Bukkit.getScheduler().runTask(instance, () -> instance.onDisable());
+                    updating.cancel();
+                    return;
+                }
+                try {
+                    testConnection.close();
+                } catch (final SQLException e) {
+                    prismDataSource.handleDataSourceException(e);
                 }
             } else {
                 notifyDisabled();
@@ -355,12 +358,7 @@ public class Prism extends JavaPlugin {
                 updating.cancel();
                 return;
             }
-            if (testConnection == null) {
-                notifyDisabled();
-                Bukkit.getScheduler().runTask(instance, () -> instance.onDisable());
-                updating.cancel();
-                return;
-            }
+
             // Info needed for setup, init these here
             handlerRegistry = new HandlerRegistry();
             actionRegistry = new ActionRegistry();
@@ -547,6 +545,7 @@ public class Prism extends JavaPlugin {
      *
      * @return true
      */
+    @Deprecated
     public boolean dependencyEnabled(String pluginName) {
         return ApiHandler.checkDependency(pluginName);
     }

--- a/src/main/java/me/botsko/prism/players/PlayerIdentification.java
+++ b/src/main/java/me/botsko/prism/players/PlayerIdentification.java
@@ -329,15 +329,7 @@ public class PlayerIdentification {
     /**
      * Build-load all online players into cache.
      */
-    public static void cacheOnlinePlayerPrimaryKeys() {
-
-        String[] playerNames;
-        playerNames = new String[Bukkit.getServer().getOnlinePlayers().size()];
-        int i = 0;
-        for (Player pl : Bukkit.getServer().getOnlinePlayers()) {
-            playerNames[i] = pl.getName();
-            i++;
-        }
+    public static void cacheOnlinePlayerPrimaryKeys(String[] playerNames) {
         try (
                 Connection conn = Prism.getPrismDataSource().getConnection();
                 PreparedStatement s = conn.prepareStatement(


### PR DESCRIPTION
This migrates all the database methods that run on enable into the asynchronous task -
This includes the world caching and player caching.
This adds a callback task that runs on a time every 5 seconds until the database is completely enabled or fails...and then cancels.  The call back will log a message to the server.log saying Prism is not configured and recording yet.

Updates are now async and should not access the Bukkit API.  
DB connection is async
Db creation and setup is async.
DB updates are async
Player and worlds are cached async.

