### PR TITLE
Prism-Bukkit-206 [BUG] Entity param not working on lookups

### DIFF
--- a/src/main/java/me/botsko/prism/actions/entity/EntitySerializer.java
+++ b/src/main/java/me/botsko/prism/actions/entity/EntitySerializer.java
@@ -1,5 +1,6 @@
 package me.botsko.prism.actions.entity;
 
+import com.google.gson.annotations.SerializedName;
 import me.botsko.prism.utils.EntityUtils;
 import me.botsko.prism.utils.MiscUtils;
 import org.bukkit.OfflinePlayer;
@@ -14,12 +15,21 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 
 public class EntitySerializer {
+    //@todo remove alternates after 2.1.7 release
     protected Boolean isAdult = null;
     protected Boolean sitting = null;
+
+    @SerializedName(value = "entityName", alternate = "entity_name")
     protected String entityName = null;
+
+    @SerializedName(value = "customName", alternate = "custom_name")
     protected String customName = null;
+
+    @SerializedName(value = "tamingOwner", alternate = "taming_owner")
     protected String tamingOwner = null;
     protected String newColor = null;
+
+    @SerializedName(value = "customDesc", alternate = "custom_desc")
     protected String customDesc = null;
 
     public final String getEntityName() {

--- a/src/main/java/me/botsko/prism/database/sql/SqlSelectQueryBuilder.java
+++ b/src/main/java/me/botsko/prism/database/sql/SqlSelectQueryBuilder.java
@@ -261,7 +261,7 @@ public class SqlSelectQueryBuilder extends QueryBuilder implements SelectQuery {
         // Entity
         final Map<String, MatchRule> entityNames = parameters.getEntities();
         if (entityNames.size() > 0) {
-            addCondition(buildMultipleConditions(entityNames, "ex.data", "entity_name\":\"%s"));
+            addCondition(buildMultipleConditions(entityNames, "ex.data", "entityName\":\"%s"));
         }
     }
 


### PR DESCRIPTION
The change to variable names introduced a serialization error.
We will need to accept the old data will not be strictly filterable - but still able to be rolled back etc as the serializer can still accept that data. but this will be removed in 2.1.8 and old data will not be parsable.

Signed-off-by: Narimm <benjicharlton@gmail.com>