### PR TITLE
Fix wierd negative permission for actions to be more consistent

### DIFF
--- a/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
+++ b/src/main/java/me/botsko/prism/commandlibs/PreprocessArgs.java
@@ -121,7 +121,7 @@ public class PreprocessArgs {
         }
 
         // Enforce specifying an action
-        if (sender != null && sender.hasPermission("prism.parameters.action.required")
+        if (sender != null && !sender.hasPermission("prism.parameters.action-filter-bypass")
                 && parameters.getActionTypes().isEmpty()) {
             sender.sendMessage(
                     Prism.messenger.playerError("You're missing valid actions. Use /prism ? for assistance."));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -231,8 +231,8 @@ permissions:
             prism.parameters.flag.*: true
     prism.parameters.action:
         default: op
-    prism.parameters.action.required:
-        default: false
+    prism.parameters.action-filter-bypass:
+        default: op
     prism.parameters.action.*:
       default: true
       children:


### PR DESCRIPTION
Change previous negative permssion for actions  To `prism.parameters.action-filter-bypass` which defaults to `op`.

The previous negative permission for prism.parameters.action.required` should be removed and is no longer used.
This new permission will allow players to avoid specifying an action filter on a lookup.

Merging will close #184 
Signed-off-by: Narimm <benjicharlton@gmail.com>