### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/Prism/src/main/java/me/botsko/prism/actions/GenericAction.java
+++ b/Prism/src/main/java/me/botsko/prism/actions/GenericAction.java
@@ -133,7 +133,7 @@ public abstract class GenericAction implements Handler {
             return "just now";
         }
 
-        long period = 24 * 60 * 60;
+        long period = (24l * 60) * 60;
 
         final long[] diff = {
               diffInSeconds / period,


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2184: 'Math operands should be cast before assignment'](https://rules.sonarsource.com/java/RSPEC-2184).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).