### PR TITLE
Fix violations of Sonar rule 2095

### DIFF
--- a/Prism/src/main/java/me/botsko/prism/database/mysql/HikariHelper.java
+++ b/Prism/src/main/java/me/botsko/prism/database/mysql/HikariHelper.java
@@ -42,15 +42,13 @@ class HikariHelper {
                 prop.setProperty("dataSource." + name, val);
             }
         }
-        try {
-            if (!propFile.getParentFile().exists() && !propFile.getParentFile().mkdirs()) {
+        try (OutputStream out = new FileOutputStream(propFile)) {
+            if ((!propFile.getParentFile().exists()) && (!propFile.getParentFile().mkdirs())) {
                 Prism.log("Prism Directory couldn't be created");
             }
-            OutputStream out = new FileOutputStream(propFile);
-            prop.store(out, "Prism Hikari Datasource Properties for"
-                    + " advanced database Configuration");
+            prop.store(out, "Prism Hikari Datasource Properties for" + " advanced database Configuration");
             Prism.log("Database Configuration saved to - " + propFile.getPath());
-        } catch (IOException e) {
+        } catch (java.io.IOException e) {
             Prism.log("Could not save Hikari.properties - " + e.getMessage());
         }
     }


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2095: 'Resources should be closed'](https://rules.sonarsource.com/java/RSPEC-2095).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2095](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#resources-should-be-closed-sonar-rule-2095).