### PR TITLE
Add more permissions for prism.alerts

### DIFF
--- a/Prism/src/main/java/me/botsko/prism/Prism.java
+++ b/Prism/src/main/java/me/botsko/prism/Prism.java
@@ -777,19 +777,20 @@ public class Prism extends JavaPlugin implements PrismApi {
     }
 
     /**
-     * Send an alert to a player.
+     * Send an alert to players.
      *
-     * @param msg String
+     * @param player    Player which caused the alert
+     * @param msg       Alert message
+     * @param alertPerm Players with this permission (or prism.alerts) will receive the alert
      */
-    public void alertPlayers(Player player, Component msg) {
+    public void alertPlayers(Player player, Component msg, String alertPerm) {
         for (final Player p : getServer().getOnlinePlayers()) {
-            if (!p.equals(player) || getConfig().getBoolean("prism.alerts.alert-player-about-self")) {
-                if (p.hasPermission("prism.alerts")) {
-                    TextComponent prefix = Il8nHelper.getMessage("alert-prefix")
+            if ((!p.equals(player) || getConfig().getBoolean("prism.alerts.alert-player-about-self"))
+                  && (p.hasPermission("prism.alerts") || (alertPerm != null && p.hasPermission(alertPerm)))) {
+                TextComponent prefix = Il8nHelper.getMessage("alert-prefix")
                             .color(NamedTextColor.RED)
                             .append(msg);
-                    audiences.player(p).sendMessage(Identity.nil(), prefix);
-                }
+                audiences.player(p).sendMessage(Identity.nil(), prefix);
             }
         }
     }

--- a/Prism/src/main/java/me/botsko/prism/PrismConfig.java
+++ b/Prism/src/main/java/me/botsko/prism/PrismConfig.java
@@ -223,7 +223,7 @@ public class PrismConfig extends ConfigBase {
         config.addDefault("prism.alerts.ores.log-commands", Collections.singletonList("examplecommand <alert>"));
         // Ore blocks
         final Map<String, String> oreBlocks = new LinkedHashMap<>();
-        oreBlocks.put(Material.IRON_ORE.name().toLowerCase(), "#444444");
+        oreBlocks.put(Material.IRON_ORE.name().toLowerCase(), "#808080");
         oreBlocks.put(Material.GOLD_ORE.name().toLowerCase(), "#ffe17d");
         oreBlocks.put(Material.LAPIS_ORE.name().toLowerCase(), "#0670cc");
         oreBlocks.put(Material.DIAMOND_ORE.name().toLowerCase(), "#04babd");
@@ -254,6 +254,7 @@ public class PrismConfig extends ConfigBase {
 
         // Use Alerts
         config.addDefault("prism.alerts.uses.enabled", true);
+        config.addDefault("prism.alerts.uses.ignore-staff", false);
         config.addDefault("prism.alerts.uses.log-to-console", true);
         config.addDefault("prism.alerts.uses.log-commands", Collections.singletonList("examplecommand <alert>"));
         config.addDefault("prism.alerts.uses.lighter", true);

--- a/Prism/src/main/java/me/botsko/prism/appliers/Preview.java
+++ b/Prism/src/main/java/me/botsko/prism/appliers/Preview.java
@@ -160,7 +160,7 @@ public class Preview implements Previewable {
                                     .replace("<processType>", processType.name().toLowerCase())
                                     .replace("<originalCommand>", parameters.getOriginalCommand(),
                                             Style.style(NamedTextColor.GRAY))
-                                    .build().colorIfAbsent(NamedTextColor.WHITE));
+                                    .build().colorIfAbsent(NamedTextColor.WHITE), null);
                         }
                     }
                 }

--- a/Prism/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
+++ b/Prism/src/main/java/me/botsko/prism/listeners/PrismBlockEvents.java
@@ -193,7 +193,7 @@ public class PrismBlockEvents extends BaseListener {
 
         // Run ore find alerts
         if (!player.hasPermission("prism.alerts.ores.ignore") && !player.hasPermission("prism.alerts.ignore")) {
-            plugin.oreMonitor.processAlertsFromBlock(player, block);
+            plugin.oreMonitor.processAlertsFromBlock(player, block, "prism.alerts.ores");
         }
 
         if (!Prism.getIgnore().event("block-break", player)) {
@@ -235,7 +235,7 @@ public class PrismBlockEvents extends BaseListener {
         // Pass to the break alerter
         if (!player.hasPermission("prism.alerts.use.break.ignore")
                 && !player.hasPermission("prism.alerts.ignore")) {
-            plugin.useMonitor.alertOnBlockBreak(player, event.getBlock());
+            plugin.useMonitor.alertOnBlockBreak(player, event.getBlock(), "prism.alerts.use.break");
         }
     }
 
@@ -265,7 +265,7 @@ public class PrismBlockEvents extends BaseListener {
 
         // Pass to the placement alerter
         if (!player.hasPermission("prism.alerts.use.place.ignore") && !player.hasPermission("prism.alerts.ignore")) {
-            plugin.useMonitor.alertOnBlockPlacement(player, block);
+            plugin.useMonitor.alertOnBlockPlacement(player, block, "prism.alerts.use.place");
         }
     }
 
@@ -457,7 +457,7 @@ public class PrismBlockEvents extends BaseListener {
                         && plugin.getConfig().getBoolean("prism.alerts.uses.lighter")
                         && !player.hasPermission("prism.alerts.use.lighter.ignore")
                         && !player.hasPermission("prism.alerts.ignore")) {
-                    plugin.useMonitor.alertOnItemUse(player, "used a " + cause);
+                    plugin.useMonitor.alertOnItemUse(player, "used a " + cause, "prism.alerts.use.lighter");
                 }
             }
 
@@ -497,7 +497,7 @@ public class PrismBlockEvents extends BaseListener {
                 final Location loc = pl.getLocation();
                 if (loc.getBlockX() == noPlayer.getX() && loc.getBlockY() == noPlayer.getY()
                         && loc.getBlockZ() == noPlayer.getZ()) {
-                    plugin.useMonitor.alertOnVanillaXray(pl, "possibly used a vanilla piston/xray trick");
+                    plugin.useMonitor.alertOnVanillaXray(pl, "possibly used a vanilla piston/xray trick", null);
                     break;
                 }
             }

--- a/Prism/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
+++ b/Prism/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
@@ -86,7 +86,7 @@ public class PrismPlayerEvents implements Listener {
                 TextComponent send = Component.text(msg);
                 Prism.messenger.sendMessage(player,
                         Prism.messenger.playerError("Sorry, this command is not available in-game."));
-                plugin.alertPlayers(null, send);
+                plugin.alertPlayers(null, send, null);
                 event.setCancelled(true);
                 // Log to console
                 if (plugin.getConfig().getBoolean("prism.alerts.illegal-commands.log-to-console")) {
@@ -302,7 +302,7 @@ public class PrismPlayerEvents implements Listener {
         if (plugin.getConfig().getBoolean("prism.alerts.uses.lava") && event.getBucket() == Material.LAVA_BUCKET
                 && !player.hasPermission("prism.alerts.use.lavabucket.ignore")
                 && !player.hasPermission("prism.alerts.ignore")) {
-            plugin.useMonitor.alertOnItemUse(player, "poured lava");
+            plugin.useMonitor.alertOnItemUse(player, "poured lava", "prism.alerts.use.lavabucket");
         }
     }
 

--- a/Prism/src/main/resources/plugin.yml
+++ b/Prism/src/main/resources/plugin.yml
@@ -55,6 +55,16 @@ permissions:
         default: op
     prism.alerts:
         default: op
+    prism.alerts.ores:
+        default: false
+    prism.alerts.use.place:
+        default: false
+    prism.alerts.use.break:
+        default: false
+    prism.alerts.use.lighter:
+        default: false
+    prism.alerts.use.lavabucket:
+        default: false
     prism.bypass-use-alerts:
         default: false
     prism.alerts.ores.ignore:


### PR DESCRIPTION
Add the following permissions to allow alert notifications to be controlled
based on the type of alert, allowing for greater flexibility:

- prism.alerts.ores
- prism.alerts.use.place
- prism.alerts.use.break
- prism.alerts.use.lighter
- prism.alerts.use.lavabucket

Also make the following corrections and improvements:

- Fix alert 'pausing warnings' message
- Count different alert types separately
- Add missing config item prism.alerts.uses.ignore-staff
- Make iron ore alerts easier to see

Fixes #250 