### PR TITLE
Updated Paper + Fix Result Set Handling

### DIFF
--- a/Prism/pom.xml
+++ b/Prism/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.1.1</version>
+            <version>4.7.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>4.0.0</version>
+            <version>4.7.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/Prism/pom.xml
+++ b/Prism/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.4.3</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.kitteh</groupId>

--- a/Prism/src/main/java/me/botsko/prism/database/sql/SqlSelectIdQueryBuilder.java
+++ b/Prism/src/main/java/me/botsko/prism/database/sql/SqlSelectIdQueryBuilder.java
@@ -60,7 +60,7 @@ public class SqlSelectIdQueryBuilder extends SqlSelectQueryBuilder implements Se
                 PreparedStatement s = connection.prepareStatement(getQuery(parameters, shouldGroup));
                 ResultSet rs = s.executeQuery()
         ) {
-            if (rs.first()) {
+            if (rs.next()) {
                 id1 = rs.getLong(1);
                 if (pair) {
                     id2 = rs.getLong(2);

--- a/Prism/src/main/java/me/botsko/prism/database/sql/SqlSelectProcessQuery.java
+++ b/Prism/src/main/java/me/botsko/prism/database/sql/SqlSelectProcessQuery.java
@@ -103,7 +103,7 @@ public class SqlSelectProcessQuery extends SqlSelectQueryBuilder implements Sele
                 PreparedStatement s = conn.prepareStatement(query);
                 ResultSet rs = s.executeQuery()
         ) {
-            if (rs.first()) {
+            if (rs.next()) {
                 process = new PrismProcessAction();
                 // Set all shared values
                 process.setId(rs.getLong("id"));
@@ -133,7 +133,7 @@ public class SqlSelectProcessQuery extends SqlSelectQueryBuilder implements Sele
                     PreparedStatement s = conn.prepareStatement(query);
                     ResultSet rs = s.executeQuery()
             ) {
-                if (rs.first()) {
+                if (rs.next()) {
                     id = rs.getLong("id");
                 }
             } catch (SQLException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <build.number/>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spigot.api.version>1.16</spigot.api.version>
-        <bukkit.version>1.16.4-R0.1-SNAPSHOT</bukkit.version>
+        <bukkit.version>1.16.5-R0.1-SNAPSHOT</bukkit.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
The latest build of Paper introduced an update to the mysql-connector. One of the changes made it more strict on the usage of `rs.first()`. Somewhere in Prism is logic to handle going forward and backwards, but with `rs.first()`, you can not do that or it will produce the following error: https://paste.gg/p/anonymous/9010ae83f15249d281d1917059c086aa

This PR changes the usage of `rs.first()` to `rs.next()` which is the "proper" usage of handling result sets.