### PR TITLE
Fixes startup check to make sure tables exist.

### DIFF
--- a/Prism/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
+++ b/Prism/src/main/java/me/botsko/prism/database/sql/SqlPrismDataSource.java
@@ -182,8 +182,7 @@ public abstract class SqlPrismDataSource implements PrismDataSource {
             // extra prism data table (check if it exists first, so we can avoid
             // re-adding foreign key stuff)
             final DatabaseMetaData metadata = conn.getMetaData();
-            ResultSet resultSet;
-            resultSet = metadata.getTables(null, null, "" + prefix + "data_extra", null);
+            ResultSet resultSet = metadata.getTables(conn.getCatalog(), conn.getSchema(), prefix + "data_extra", new String[]{"TABLE"});
             if (!resultSet.next()) {
 
                 // extra data


### PR DESCRIPTION
Fixes startup check to make sure tables exist. If "xxx_data_extra" was already defined in another database/schema, then it wouldnt create another in the new schema.