### PR TITLE
Update adventure-api. 

### DIFF
--- a/Prism/pom.xml
+++ b/Prism/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.7.0</version>
+            <version>4.8.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>

--- a/Prism/pom.xml
+++ b/Prism/pom.xml
@@ -31,6 +31,7 @@
             <artifactId>Prism-Api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+	<!-- Useless comment to test Codacy -->
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>

--- a/Prism/pom.xml
+++ b/Prism/pom.xml
@@ -31,7 +31,6 @@
             <artifactId>Prism-Api</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
-	<!-- Useless comment to test Codacy -->
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>


### PR DESCRIPTION
Fixes "NoClassDefFoundError: com/botsko/prism/libs/adventure/sound/Sound$Emitter" in build 222