### PR TITLE
bump the snapshot to 4.0.1

### DIFF
--- a/Prism/pom.xml
+++ b/Prism/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.0.0-SNAPSHOT</version>
+            <version>4.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>

--- a/Prism/pom.xml
+++ b/Prism/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.8.1</version>
+            <version>4.9.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>


### PR DESCRIPTION
Closes https://github.com/AddstarMC/Prism-Bukkit/issues/291

This PR bumps the version of `net.kyori:adventure-platform-bukkit` to 4.0.1, which allows maven to successfully package prism. It also bumps the `net.kyori:adventure-api` to 4.9.3 because that works with `4.0.1`