### PR TITLE
Fix bed rollback and Shulker box improvements

### DIFF
--- a/Prism/src/main/java/me/botsko/prism/actions/BlockAction.java
+++ b/Prism/src/main/java/me/botsko/prism/actions/BlockAction.java
@@ -338,10 +338,18 @@ public class BlockAction extends GenericAction {
     private @NotNull ChangeResult handleApply(final Block block, final BlockState originalBlock,
                                                   final PrismParameters parameters, final boolean cancelIfBadPlace) {
         BlockState state = block.getState();
-        // If lily pad, check that block below is water. Be sure
-        // it's set to stationary water so the lily pad will sit
+
+        // We always track the FOOT of the bed when broken, regardless of which block is broken.
+        // But we always need to destroy the HEAD of the bed otherwise Minecraft drops a bed item.
+        // So this will ensure the head of the bed is broken when removing the bed during rollback.
+        if (MaterialTag.BEDS.isTagged(state.getType())) {
+            state = Utilities.getSiblingForDoubleLengthBlock(state).getState();
+        }
+
         switch (getMaterial()) {
             case LILY_PAD:
+                // If restoring a lily pad, check that block below is water.
+                // Be sure it's set to stationary water so the lily pad will stay
                 final Block below = block.getRelative(BlockFace.DOWN);
                 if (below.getType().equals(WATER) || below.getType().equals(AIR)) {
                     below.setType(WATER);
@@ -350,7 +358,8 @@ public class BlockAction extends GenericAction {
                     return new ChangeResultImpl(ChangeResultType.SKIPPED, null);
                 }
                 break;
-            case NETHER_PORTAL: // Only way is to set the portal on fire.
+            case NETHER_PORTAL:
+                // Only way to restore a nether portal is to set it on fire.
                 final Block obsidian = Utilities.getFirstBlockOfMaterialBelow(OBSIDIAN, block.getLocation());
                 if (obsidian != null) {
                     final Block above = obsidian.getRelative(BlockFace.UP);

--- a/Prism/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
+++ b/Prism/src/main/java/me/botsko/prism/listeners/PrismPlayerEvents.java
@@ -413,7 +413,7 @@ public class PrismPlayerEvents implements Listener {
         // as of 1.4
         if (block != null && event.getAction() == Action.RIGHT_CLICK_BLOCK) {
             String coordKey;
-            if (MaterialTag.CONTAINERS.isTagged(block.getType()) || MaterialTag.SHULKER_BOXES.isTagged(block.getType())) {
+            if (MaterialTag.CONTAINERS.isTagged(block.getType())) {
                 if (!Prism.getIgnore().event("container-access", player)) {
                     return;
                 }

--- a/Prism/src/main/java/me/botsko/prism/utils/MaterialTag.java
+++ b/Prism/src/main/java/me/botsko/prism/utils/MaterialTag.java
@@ -54,9 +54,9 @@ public class MaterialTag implements Tag<Material> {
             Material.SMITHING_TABLE,Material.BREWING_STAND,Material.ENCHANTING_TABLE,Material.SMOKER,Material.FURNACE,
             Material.BLAST_FURNACE);
     public static final MaterialTag CONTAINERS = new MaterialTag(CRAFTING).append(
-            Material.CHEST,Material.BARREL,Material.ENDER_CHEST,Material.TRAPPED_CHEST,Material.CHEST_MINECART,
-            Material.DROPPER,Material.DISPENSER, Material.HOPPER,Material.HOPPER_MINECART
-    );
+            Material.CHEST, Material.BARREL, Material.ENDER_CHEST, Material.TRAPPED_CHEST, Material.CHEST_MINECART,
+            Material.DROPPER, Material.DISPENSER, Material.HOPPER, Material.HOPPER_MINECART)
+            .append(Tag.SHULKER_BOXES);
     public static final MaterialTag USABLE = new MaterialTag(Tag.BUTTONS).append(Tag.DOORS).append(Tag.TRAPDOORS)
             .append(Material.LEVER).append(Tag.FENCE_GATES);
     // Affected by bone meal.


### PR DESCRIPTION
This introduces two minor fixes:
* Fix bed item being dropped when rolling back a bed placement. Minecraft will drop a bed item if you destroy the "foot" block of a bed but not when you destroy the "head" block, so this implements a minor change to always remove the head block.
* Add all types of shulker boxes to the "container" material list, ensuring they're always detected as containers anywhere throughout Prism.